### PR TITLE
Fixes MAISTRA-1168: added implementation of boringssl function SSL_get_peer_full_cert_chain

### DIFF
--- a/source/extensions/transport_sockets/tls/openssl_impl.cc
+++ b/source/extensions/transport_sockets/tls/openssl_impl.cc
@@ -90,6 +90,24 @@ std::string getSerialNumberFromCertificate(X509* cert) {
   return "";
 }
 
+STACK_OF(X509)* SSL_get_peer_full_cert_chain(const SSL *ssl) {
+  STACK_OF(X509)* to_copy = SSL_get_peer_cert_chain(ssl);
+  if (!to_copy) {
+    return nullptr;
+  }
+  STACK_OF(X509)* ret = sk_X509_dup(SSL_get_peer_cert_chain(ssl));
+
+  if (SSL_is_server(ssl)) {
+    X509* peer_cert = SSL_get_peer_certificate(ssl);
+    if (!sk_X509_insert(ret, peer_cert, 0)) {
+      sk_X509_pop_free(ret, X509_free);
+      return nullptr;
+    }
+  }
+
+  return ret;
+}
+
 void allowRenegotiation(SSL* ssl) {
   // SSL_set_renegotiate_mode(ssl, mode);
 }

--- a/source/extensions/transport_sockets/tls/openssl_impl.h
+++ b/source/extensions/transport_sockets/tls/openssl_impl.h
@@ -28,6 +28,8 @@ int set_strict_cipher_list(SSL_CTX* ctx, const char* str);
 
 std::string getSerialNumberFromCertificate(X509* cert);
 
+STACK_OF(X509)* SSL_get_peer_full_cert_chain(const SSL *ssl);
+
 void allowRenegotiation(SSL* ssl);
 
 bssl::UniquePtr<STACK_OF(X509_NAME)> initX509Names();

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -381,7 +381,7 @@ const std::string& SslSocketInfo::urlEncodedPemEncodedPeerCertificateChain() con
     return cached_url_encoded_pem_encoded_peer_cert_chain_;
   }
 
-  STACK_OF(X509)* cert_chain = SSL_get_peer_cert_chain(ssl_.get());
+  STACK_OF(X509)* cert_chain = SSL_get_peer_full_cert_chain(ssl_.get());
   if (cert_chain == nullptr) {
     ASSERT(cached_url_encoded_pem_encoded_peer_cert_chain_.empty());
     return cached_url_encoded_pem_encoded_peer_cert_chain_;

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -1137,8 +1137,7 @@ TEST_P(SslSocketTest, GetPeerCert) {
                .setExpectedPeerCert(expected_peer_cert));
 }
 
-TEST_P(SslSocketTest, DISABLED_GetPeerCertChain) {
-  std::cout << "11111111111111111111111111111111111111111111111111111111111111111111111111111111\n";
+TEST_P(SslSocketTest, GetPeerCertChain) {
   const std::string client_ctx_yaml = R"EOF(
   common_tls_context:
     tls_certificates:
@@ -1168,7 +1167,6 @@ TEST_P(SslSocketTest, DISABLED_GetPeerCertChain) {
           "}}/test/extensions/transport_sockets/tls/test_data/no_san_chain.pem"));
   testUtil(test_options.setExpectedSerialNumber(TEST_NO_SAN_CERT_SERIAL)
                .setExpectedPeerCertChain(expected_peer_cert_chain));
-  std::cout << "222222222222222222222222222222222222222222222222222222222222222222222222222222222222\n";
 }
 
 TEST_P(SslSocketTest, GetIssueExpireTimesPeerCert) {


### PR DESCRIPTION
This fixes MAISTRA-1168.

The issue was that the openssl call (SSL_get_peer_cert_chain) that we used to substitute a boringssl one (SSL_get_peer_full_cert_chain) doesn't return a full certificate chain when called on the server: client peer certificate needs to be retrieved separately (see https://www.openssl.org/docs/man1.1.0/man3/SSL_get_peer_cert_chain.html for more details). I added an implementation of SSL_get_peer_full_cert_chain that emulates boringssl behaviour.