### PR TITLE
added an explanation why DynamicOpentracingHttpTracer has been disabled

### DIFF
--- a/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
@@ -53,7 +53,10 @@ TEST_F(DynamicOpenTracingDriverTest, formatErrorMessage) {
             DynamicOpenTracingDriver::formatErrorMessage(error_code, "abc"));
 }
 
-// TODO (dmitri-d): memory leak is reported in this test
+// Disabled due to heapcheck reporting false positives when the test is statically linked with libstdc++
+// See https://github.com/envoyproxy/envoy/issues/7647 for the discussion
+// TODO (dmitri-d) there currently isn't a way to resolve this: some tests will fail when libstdc++ is
+// dynamically linked, this test fails when it's statically linked
 TEST_F(DynamicOpenTracingDriverTest, DISABLED_InitializeDriver) {
   {
     std::string invalid_library = "abc123";
@@ -71,7 +74,10 @@ TEST_F(DynamicOpenTracingDriverTest, DISABLED_InitializeDriver) {
   }
 }
 
-// TODO (dmitri-d): Fix "JSON supplied is not valid" error
+// Disabled due to failing with "JSON supplied is not valid" error when the test is statically linked with libstdc++
+// See https://github.com/envoyproxy/envoy/issues/7647 for the discussion
+// TODO (dmitri-d) there currently isn't a way to resolve this: some tests will fail when libstdc++ is
+// dynamically linked, this test fails when it's statically linked
 TEST_F(DynamicOpenTracingDriverTest, DISABLED_FlushSpans) {
   setupValidDriver();
 


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
