### PR TITLE
Fixes MAISTRA-1226: added support for importPublicKey in lua filter

### DIFF
--- a/source/extensions/common/crypto/utility_impl.cc
+++ b/source/extensions/common/crypto/utility_impl.cc
@@ -52,6 +52,7 @@ const VerificationOutput UtilityImpl::verifySignature(absl::string_view hash, Cr
   if (md == nullptr) {
     return {false, absl::StrCat(hash, " is not supported.")};
   }
+
   // Step 3: initialize EVP_DigestVerify
   auto pkey_wrapper = Common::Crypto::Access::getTyped<Common::Crypto::PublicKeyObject>(key);
   EVP_PKEY* pkey = pkey_wrapper->getEVP_PKEY();
@@ -77,10 +78,9 @@ const VerificationOutput UtilityImpl::verifySignature(absl::string_view hash, Cr
   return {false, absl::StrCat("Failed to verify digest. Error code: ", ok)};
 }
 
-// This is a dummy implementation of the interface, as EVP_parse_public_key isn't available under OpenSSL
 CryptoObjectPtr UtilityImpl::importPublicKey(const std::vector<uint8_t>& key) {
-  CBS cbs({key.data(), key.size()});
-  return std::make_unique<PublicKeyObject>(); //EVP_parse_public_key(&cbs));
+  const unsigned char* tmp = key.data();
+  return std::make_unique<PublicKeyObject>(d2i_PUBKEY(nullptr, &tmp, key.size()));
 }
 
 const EVP_MD* UtilityImpl::getHashFunction(absl::string_view name) {

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -468,6 +468,22 @@ int StreamHandleWrapper::luaVerifySignature(lua_State* state) {
   return 2;
 }
 
+int StreamHandleWrapper::luaImportPublicKey(lua_State* state) {
+  // Get byte array and the length.
+  const char* str = luaL_checkstring(state, 2);
+  int n = luaL_checknumber(state, 3);
+  std::vector<uint8_t> key(str, str + n);
+  if (public_key_wrapper_.get() != nullptr) {
+    public_key_wrapper_.pushStack();
+  } else {
+    auto& crypto_util = Envoy::Common::Crypto::UtilitySingleton::get();
+    Common::Crypto::CryptoObjectPtr crypto_ptr = crypto_util.importPublicKey(key);
+    public_key_wrapper_.reset(PublicKeyWrapper::create(state, std::move(crypto_ptr)), true);
+  }
+
+  return 1;
+}
+
 FilterConfig::FilterConfig(const std::string& lua_code, ThreadLocal::SlotAllocator& tls,
                            Upstream::ClusterManager& cluster_manager)
     : cluster_manager_(cluster_manager), lua_state_(lua_code, tls) {

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -144,6 +144,7 @@ public:
             {"respond", static_luaRespond},
             {"streamInfo", static_luaStreamInfo},
             {"connection", static_luaConnection},
+            {"importPublicKey", static_luaImportPublicKey},
             {"verifySignature", static_luaVerifySignature}};
   }
 
@@ -231,6 +232,14 @@ private:
    * the second element stores the error message
    */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaVerifySignature);
+
+  /**
+   * Import public key.
+   * @param 1 (string) keyder string
+   * @param 2 (int)    length of keyder string
+   * @return pointer to public key
+   */
+  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaImportPublicKey);
 
   /**
    * This is the closure/iterator returned by luaBodyChunks() above.

--- a/test/common/crypto/utility_test.cc
+++ b/test/common/crypto/utility_test.cc
@@ -54,7 +54,7 @@ TEST(UtilityTest, TestSha256HmacWithEmptyArguments) {
 }
 
 // TODO (dmitri-d) re-enabled when importPublicKey OpenSSL-compatible implementation has been added
-TEST(UtilityTest, DISABLED_TestImportPublicKey) {
+TEST(UtilityTest, TestImportPublicKey) {
   auto key = "30820122300d06092a864886f70d01010105000382010f003082010a0282010100a7471266d01d160308d"
              "73409c06f2e8d35c531c458d3e480e9f3191847d062ec5ccff7bc51e949d5f2c3540c189a4eca1e8633a6"
              "2cf2d0923101c27e38013e71de9ae91a704849bff7fbe2ce5bf4bd666fd9731102a53193fe5a9a5a50644"
@@ -77,7 +77,7 @@ TEST(UtilityTest, DISABLED_TestImportPublicKey) {
 }
 
 // TODO (dmitri-d) re-enabled when importPublicKey OpenSSL-compatible implementation has been added
-TEST(UtilityTest, DISABLED_TestVerifySignature) {
+TEST(UtilityTest, TestVerifySignature) {
   auto key = "30820122300d06092a864886f70d01010105000382010f003082010a0282010100a7471266d01d160308d"
              "73409c06f2e8d35c531c458d3e480e9f3191847d062ec5ccff7bc51e949d5f2c3540c189a4eca1e8633a6"
              "2cf2d0923101c27e38013e71de9ae91a704849bff7fbe2ce5bf4bd666fd9731102a53193fe5a9a5a50644"

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1608,7 +1608,7 @@ TEST_F(LuaHttpFilterTest, CheckConnection) {
 }
 
 // TODO (dmitri-d) re-enable after importPublicKey method has been fixed
-TEST_F(LuaHttpFilterTest, DISABLED_ImportPublicKey) {
+TEST_F(LuaHttpFilterTest, ImportPublicKey) {
   const std::string SCRIPT{R"EOF(
     function string.fromhex(str)
       return (str:gsub('..', function (cc)
@@ -1638,7 +1638,7 @@ TEST_F(LuaHttpFilterTest, DISABLED_ImportPublicKey) {
 }
 
 // TODO (dmitri-d) re-enable when importPublicKey has been fixed
-TEST_F(LuaHttpFilterTest, DISABLED_InvalidPublicKey) {
+TEST_F(LuaHttpFilterTest, InvalidPublicKey) {
   const std::string SCRIPT{R"EOF(
     function string.fromhex(str)
       return (str:gsub('..', function (cc)
@@ -1668,7 +1668,7 @@ TEST_F(LuaHttpFilterTest, DISABLED_InvalidPublicKey) {
 }
 
 // TODO (dmitri-d) re-enable when importPublicKey has been fixed
-TEST_F(LuaHttpFilterTest, DISABLED_SignatureVerify) {
+TEST_F(LuaHttpFilterTest, SignatureVerify) {
   const std::string SCRIPT{R"EOF(
     function string.fromhex(str)
       return (str:gsub('..', function (cc)

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -423,7 +423,7 @@ typed_config:
 
 // TODO (dmitri-d) re-enable when importPublicKey method is added
 // Basic test for verifying signature.
-TEST_P(LuaIntegrationTest, DISABLED_SignatureVerification) {
+TEST_P(LuaIntegrationTest, SignatureVerification) {
   const std::string FILTER_AND_CODE =
       R"EOF(
 name: envoy.lua
@@ -470,7 +470,7 @@ typed_config:
       local sig = request_handle:headers():get("signature")
       local rawsig = sig:fromhex()
       local data = request_handle:headers():get("message")
-      local ok, error = request_handle:verifySignature(hash, pubkey, rawsig, string.len(rawsig), data, string.len(data)) 
+      local ok, error = request_handle:verifySignature(hash, pubkey, rawsig, string.len(rawsig), data, string.len(data))
 
       if ok then
         request_handle:headers():add("signature_verification", "approved")


### PR DESCRIPTION
This is the second part of a fix for https://issues.redhat.com/browse/MAISTRA-1226. The first part of the fix: https://github.com/Maistra/bssl_wrapper/pull/3