### PR TITLE
Fixes MAISTRA-1265: Upstream release 1.4.6 + alpn fixes + latest bssl_wrapper

### DIFF
--- a/bazel/external/openssl_includes-1.patch
+++ b/bazel/external/openssl_includes-1.patch
@@ -1,0 +1,13 @@
+diff --git a/ssl/packet_locl.h b/ssl/packet_locl.h
+index 860360b8b2..49c719285f 100644
+--- a/ssl/packet_locl.h
++++ b/ssl/packet_locl.h
+@@ -426,7 +426,7 @@ __owur static ossl_inline int PACKET_memdup(const PACKET *pkt,
+     if (length == 0)
+         return 1;
+ 
+-    *data = OPENSSL_memdup(pkt->curr, length);
++    *data = (unsigned char *)OPENSSL_memdup(pkt->curr, length);
+     if (*data == NULL)
+         return 0;
+ 

--- a/bazel/external/openssl_includes.BUILD
+++ b/bazel/external/openssl_includes.BUILD
@@ -1,0 +1,18 @@
+cc_library(
+    name = "openssl_includes_lib",
+    copts = ["-Wno-error=error"],
+    hdrs = [
+            "e_os.h", 
+            "ssl/ssl_locl.h", 
+            "ssl/packet_locl.h", 
+            "ssl/record/record.h", 
+            "ssl/statem/statem.h", 
+            "include/internal/dane.h",
+            "include/internal/nelem.h",
+            "include/internal/numbers.h",
+            "include/internal/refcount.h",
+            "include/internal/tsan_assist.h",
+    ],
+    includes = ["ssl", "ssl/record", "ssl/statem", "include",],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -109,6 +109,7 @@ def envoy_dependencies(skip_targets = []):
 
     # EXTERNAL OPENSSL
     _openssl()
+    _openssl_includes()
     _bssl_wrapper()
     _openssl_cbs()
 
@@ -181,6 +182,21 @@ def _openssl():
         name = "ssl",
         actual = "@openssl//:openssl-lib",
 )
+
+def _openssl_includes():
+    _repository_impl(
+        name = "com_github_openssl_openssl",
+        build_file = "@envoy//bazel/external:openssl_includes.BUILD",
+        patches = [
+            "@envoy//bazel/external:openssl_includes-1.patch",
+        ],
+        patch_args = ["-p1"],
+    )
+    native.bind(
+        name = "openssl_includes_lib",
+        actual = "@com_github_openssl_openssl//:openssl_includes_lib",
+)
+
 
 #EXTERNAL OPENSSL
 def _bssl_wrapper():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -21,6 +21,11 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "envoy-build-tools-a6b28555badcb18d6be924c8fc1bea49971656b8",
         urls = ["https://github.com/envoyproxy/envoy-build-tools/archive/a6b28555badcb18d6be924c8fc1bea49971656b8.tar.gz"],
     ),
+    com_github_openssl_openssl = dict(
+        sha256 = "cf26f056a955cff721d3a3c08d8126d1e4f69803e08c9600dac3b6b7158586d6",
+        strip_prefix = "openssl-894da2fb7ed5d314ee5c2fc9fd2d9b8b74111596",
+        urls = ["https://github.com/openssl/openssl/archive/894da2fb7ed5d314ee5c2fc9fd2d9b8b74111596.tar.gz"],
+     ),
     #EXTERNAL OPENSSL
     bssl_wrapper = dict(
         sha256 = "d84ea7d190210145695e5b172e8e6fb23f3464360da5efab5a1ae1a973c21f57",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -23,9 +23,9 @@ REPOSITORY_LOCATIONS = dict(
     ),
     #EXTERNAL OPENSSL
     bssl_wrapper = dict(
-        sha256 = "81a59d013096015a93269325ee4148d826ffd7a9f019f622850a2b86974b9748",
-        strip_prefix = "bssl_wrapper-2eaed8832e12a0fada8f08a5e23522e035b80784",
-        urls = ["https://github.com/maistra/bssl_wrapper/archive/2eaed8832e12a0fada8f08a5e23522e035b80784.tar.gz"],
+        sha256 = "d84ea7d190210145695e5b172e8e6fb23f3464360da5efab5a1ae1a973c21f57",
+        strip_prefix = "bssl_wrapper-c9649facde3ab1d8bc871c7375a8946c50950e97",
+        urls = ["https://github.com/maistra/bssl_wrapper/archive/c9649facde3ab1d8bc871c7375a8946c50950e97.tar.gz"],
     ),
     #EXTERNAL OPENSSL
     openssl_cbs = dict(

--- a/docs/root/configuration/http/http_conn_man/stats.rst
+++ b/docs/root/configuration/http/http_conn_man/stats.rst
@@ -111,6 +111,7 @@ All http1 statistics are rooted at *http1.*
    :widths: 1, 1, 2
 
    metadata_not_supported_error, Counter, Total number of metadata dropped during HTTP/1 encoding
+   response_flood, Counter, Total number of connections closed due to response flooding
 
 Http2 codec statistics
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/root/intro/arch_overview/security/rbac_filter.rst
+++ b/docs/root/intro/arch_overview/security/rbac_filter.rst
@@ -81,6 +81,7 @@ The following attributes are exposed to the language runtime:
    response.headers, string map, All response headers
    response.trailers, string map, All response trailers
    response.size, int, Size of the response body
+   response.total_size, int, Total size of the response including the approximate uncompressed size of the headers and the trailers
    response.flags, int, Additional details about the response beyond the standard response code
    source.address, string, Downstream connection remote address
    source.port, int, Downstream connection remote port

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -1,6 +1,25 @@
 Version history
 ---------------
 
+1.12.3 (Pending)
+==========================
+* buffer: force copy when appending small slices to OwnedImpl buffer to avoid fragmentation.
+* listeners: fixed issue where :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` could have been bypassed by a client using only TLS 1.3.
+* sds: fixed the SDS vulnerability that TLS validation context (e.g., subject alt name or hash) cannot be effectively validated in some cases.
+* http: added HTTP/1.1 flood protection. Can be temporarily disabled using the runtime feature `envoy.reloadable_features.http1_flood_protection`.
+
+1.12.2 (December 10, 2019)
+==========================
+* http: fixed CVE-2019-18801 by allocating sufficient memory for request headers.
+* http: fixed CVE-2019-18802 by implementing stricter validation of HTTP/1 headers.
+* http: trim LWS at the end of header keys, for correct HTTP/1.1 header parsing.
+* http: added strict authority checking. This can be reversed temporarily by setting the runtime feature `envoy.reloadable_features.strict_authority_validation` to false.
+* route config: fixed CVE-2019-18838 by checking for presence of host/path headers.
+
+1.12.1 (November 8, 2019)
+=========================
+* listener: fixed CVE-2019-18836 by clearing accept filters before connection creation.
+
 1.12.0 (October 31, 2019)
 =========================
 * access log: added a new flag for :ref:`downstream protocol error <envoy_api_field_data.accesslog.v2.ResponseFlags.downstream_protocol_error>`.

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -101,8 +101,8 @@ public:
   /**
    * Commit a set of slices originally obtained from reserve(). The number of slices should match
    * the number obtained from reserve(). The size of each slice can also be altered. Commit must
-   * occur following a reserve() without any mutating operations in between other than to the iovecs
-   * len_ fields.
+   * occur once following a reserve() without any mutating operations in between other than to the
+   * iovecs len_ fields.
    * @param iovecs supplies the array of slices to commit.
    * @param num_iovecs supplies the size of the slices array.
    */

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -10,8 +10,15 @@
 
 namespace Envoy {
 namespace Buffer {
+namespace {
+// This size has been determined to be optimal from running the
+// //test/integration:http_benchmark benchmark tests.
+// TODO(yanavlasov): This may not be optimal for all hardware configurations or traffic patterns and
+// may need to be configurable in the future.
+constexpr uint64_t CopyThreshold = 512;
+} // namespace
 
-void OwnedImpl::add(const void* data, uint64_t size) {
+void OwnedImpl::addImpl(const void* data, uint64_t size) {
   if (old_impl_) {
     evbuffer_add(buffer_.get(), data, size);
   } else {
@@ -29,6 +36,8 @@ void OwnedImpl::add(const void* data, uint64_t size) {
     }
   }
 }
+
+void OwnedImpl::add(const void* data, uint64_t size) { addImpl(data, size); }
 
 void OwnedImpl::addBufferFragment(BufferFragment& fragment) {
   if (old_impl_) {
@@ -150,6 +159,11 @@ void OwnedImpl::commit(RawSlice* iovecs, uint64_t num_iovecs) {
       }
     }
 
+    // In case an extra slice was reserved, remove empty slices from the end of the buffer.
+    while (!slices_.empty() && slices_.back()->dataSize() == 0) {
+      slices_.pop_back();
+    }
+
     ASSERT(num_slices_committed > 0);
   }
 }
@@ -212,6 +226,11 @@ void OwnedImpl::drain(uint64_t size) {
         size = 0;
       }
     }
+  }
+  // Make sure to drain any zero byte fragments that might have been added as
+  // sentinels for flushed data.
+  while (!slices_.empty() && slices_.front()->dataSize() == 0) {
+    slices_.pop_front();
   }
 }
 
@@ -299,6 +318,26 @@ void* OwnedImpl::linearize(uint32_t size) {
   }
 }
 
+void OwnedImpl::coalesceOrAddSlice(SlicePtr&& other_slice) {
+  const uint64_t slice_size = other_slice->dataSize();
+  // The `other_slice` content can be coalesced into the existing slice IFF:
+  // 1. The `other_slice` can be coalesced. Objects of type UnownedSlice can not be coalesced. See
+  //    comment in the UnownedSlice class definition;
+  // 2. There are existing slices;
+  // 3. The `other_slice` content length is under the CopyThreshold;
+  // 4. There is enough unused space in the existing slice to accommodate the `other_slice` content.
+  if (other_slice->canCoalesce() && !slices_.empty() && slice_size < CopyThreshold &&
+      slices_.back()->reservableSize() >= slice_size) {
+    // Copy content of the `other_slice`. The `move` methods which call this method effectively
+    // drain the source buffer.
+    addImpl(other_slice->data(), slice_size);
+  } else {
+    // Take ownership of the slice.
+    slices_.emplace_back(std::move(other_slice));
+    length_ += slice_size;
+  }
+}
+
 void OwnedImpl::move(Instance& rhs) {
   ASSERT(&rhs != this);
   ASSERT(isSameBufferImpl(rhs));
@@ -318,10 +357,9 @@ void OwnedImpl::move(Instance& rhs) {
     OwnedImpl& other = static_cast<OwnedImpl&>(rhs);
     while (!other.slices_.empty()) {
       const uint64_t slice_size = other.slices_.front()->dataSize();
-      slices_.emplace_back(std::move(other.slices_.front()));
-      other.slices_.pop_front();
-      length_ += slice_size;
+      coalesceOrAddSlice(std::move(other.slices_.front()));
       other.length_ -= slice_size;
+      other.slices_.pop_front();
     }
     other.postProcess();
   }
@@ -351,9 +389,8 @@ void OwnedImpl::move(Instance& rhs, uint64_t length) {
         other.slices_.front()->drain(copy_size);
         other.length_ -= copy_size;
       } else {
-        slices_.emplace_back(std::move(other.slices_.front()));
+        coalesceOrAddSlice(std::move(other.slices_.front()));
         other.slices_.pop_front();
-        length_ += slice_size;
         other.length_ -= slice_size;
       }
       length -= copy_size;
@@ -649,6 +686,14 @@ bool OwnedImpl::isSameBufferImpl(const Instance& rhs) const {
     return false;
   }
   return usesOldImpl() == other->usesOldImpl();
+}
+
+std::vector<OwnedSlice::SliceRepresentation> OwnedImpl::describeSlicesForTest() const {
+  std::vector<OwnedSlice::SliceRepresentation> slices;
+  for (const auto& slice : slices_) {
+    slices.push_back(slice->describeSliceForTest());
+  }
+  return slices;
 }
 
 bool OwnedImpl::use_old_impl_ = false;

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -196,6 +196,13 @@ void ConnectionImpl::closeSocket(ConnectionEvent close_type) {
   // Drain input and output buffers.
   updateReadBufferStats(0, 0);
   updateWriteBufferStats(0, 0);
+
+  // As the socket closes, drain any remaining data.
+  // The data won't be written out at this point, and where there are reference
+  // counted buffer fragments, it helps avoid lifetime issues with the
+  // connection outlasting the subscriber.
+  write_buffer_->drain(write_buffer_->length());
+
   connection_stats_.reset();
 
   file_event_.reset();

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -24,6 +24,7 @@ namespace Runtime {
 // problem of the bugs being found after the old code path has been removed.
 constexpr const char* runtime_features[] = {
     // Enabled
+    "envoy.reloadable_features.http1_flood_protection",
     "envoy.reloadable_features.test_feature_true",
     "envoy.reloadable_features.buffer_filter_populate_content_length",
     "envoy.reloadable_features.trusted_forwarded_proto",

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -37,7 +37,7 @@ bool runtimeFeatureEnabled(absl::string_view feature) {
 }
 
 uint64_t getInteger(absl::string_view feature, uint64_t default_value) {
-  ASSERT(absl::StartsWith(feature, "envoy.reloadable_features"));
+  ASSERT(absl::StartsWith(feature, "envoy."));
   if (Runtime::LoaderSingleton::getExisting()) {
     return Runtime::LoaderSingleton::getExisting()->threadsafeSnapshot()->getInteger(
         std::string(feature), default_value);

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -124,6 +124,9 @@ public:
     return nullptr;
   }
   Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) override {
+    if (secret()) {
+      callback();
+    }
     return update_callback_manager_.add(callback);
   }
 
@@ -174,6 +177,9 @@ public:
     return certificate_validation_context_secrets_.get();
   }
   Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) override {
+    if (secret()) {
+      callback();
+    }
     return update_callback_manager_.add(callback);
   }
 
@@ -237,6 +243,9 @@ public:
   }
 
   Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) override {
+    if (secret()) {
+      callback();
+    }
     return update_callback_manager_.add(callback);
   }
 

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -77,6 +77,9 @@ absl::optional<CelValue> RequestWrapper::operator[](CelValue key) const {
     } else {
       return CelValue::CreateInt64(info_.bytesReceived());
     }
+  } else if (value == TotalSize) {
+    return CelValue::CreateInt64(info_.bytesReceived() +
+                                 (headers_.value_ ? headers_.value_->byteSize().value() : 0));
   } else if (value == Duration) {
     auto duration = info_.requestComplete();
     if (duration.has_value()) {
@@ -106,8 +109,6 @@ absl::optional<CelValue> RequestWrapper::operator[](CelValue key) const {
       return convertHeaderEntry(headers_.value_->RequestId());
     } else if (value == UserAgent) {
       return convertHeaderEntry(headers_.value_->UserAgent());
-    } else if (value == TotalSize) {
-      return CelValue::CreateInt64(info_.bytesReceived() + headers_.value_->byteSize().value());
     }
   }
   return {};
@@ -131,6 +132,10 @@ absl::optional<CelValue> ResponseWrapper::operator[](CelValue key) const {
     return CelValue::CreateMap(&trailers_);
   } else if (value == Flags) {
     return CelValue::CreateInt64(info_.responseFlags());
+  } else if (value == TotalSize) {
+    return CelValue::CreateInt64(info_.bytesSent() +
+                                 (headers_.value_ ? headers_.value_->byteSize().value() : 0) +
+                                 (trailers_.value_ ? trailers_.value_->byteSize().value() : 0));
   }
   return {};
 }

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -76,6 +76,7 @@ public:
 
 private:
   friend class RequestWrapper;
+  friend class ResponseWrapper;
   const Http::HeaderMap* value_;
 };
 

--- a/source/extensions/filters/listener/tls_inspector/BUILD
+++ b/source/extensions/filters/listener/tls_inspector/BUILD
@@ -18,9 +18,9 @@ envoy_cc_library(
     external_deps = [
         "ssl",
         "bssl_wrapper_lib",
+        "openssl_includes_lib",
     ],
     deps = [
-        ":openssl_impl_lib",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:timer_interface",
         "//include/envoy/network:filter_interface",
@@ -40,19 +40,5 @@ envoy_cc_library(
         "//include/envoy/server:filter_config_interface",
         "//source/extensions/filters/listener:well_known_names",
         "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
-    ],
-)
-
-envoy_cc_library(
-    name = "openssl_impl_lib",
-    srcs = [
-        "openssl_impl.cc",
-    ],
-    hdrs = [
-        "openssl_impl.h",
-    ],
-    external_deps = [
-        "ssl",
-        "bssl_wrapper_lib",
     ],
 )

--- a/source/extensions/filters/listener/tls_inspector/openssl_impl.cc
+++ b/source/extensions/filters/listener/tls_inspector/openssl_impl.cc
@@ -17,34 +17,21 @@ namespace Extensions {
 namespace ListenerFilters {
 namespace TlsInspector {
 
-const SSL_METHOD* TLS_with_buffers_method(void) { return TLS_method(); }
-
-void set_certificate_cb(SSL_CTX* ctx) {
-  auto cert_cb = [](SSL* ssl, void* arg) -> int { return 0; };
-  SSL_CTX_set_cert_cb(ctx, cert_cb, ctx);
-}
-
 std::vector<absl::string_view> getAlpnProtocols(const unsigned char* data, unsigned int len) {
   std::vector<absl::string_view> protocols;
   absl::string_view str(reinterpret_cast<const char*>(data));
   for (int i = 0; i < len;) {
-
     uint32_t protocol_length = 0;
     protocol_length <<= 8;
     protocol_length |= data[i];
-
     ++i;
-
     absl::string_view protocol(str.substr(i, protocol_length));
     protocols.push_back(protocol);
-
     i += protocol_length;
   }
 
   return protocols;
 }
-
-int getServernameCallbackReturn(int* out_alert) { return SSL_TLSEXT_ERR_OK; }
 
 } // namespace TlsInspector
 } // namespace ListenerFilters

--- a/source/extensions/filters/listener/tls_inspector/openssl_impl.h
+++ b/source/extensions/filters/listener/tls_inspector/openssl_impl.h
@@ -16,12 +16,7 @@ namespace Extensions {
 namespace ListenerFilters {
 namespace TlsInspector {
 
-const SSL_METHOD* TLS_with_buffers_method();
-
-void set_certificate_cb(SSL_CTX* ctx);
-
 std::vector<absl::string_view> getAlpnProtocols(const unsigned char* data, unsigned int len);
-int getServernameCallbackReturn(int* out_alert);
 
 } // namespace TlsInspector
 } // namespace ListenerFilters

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -24,6 +24,10 @@ namespace Extensions {
 namespace ListenerFilters {
 namespace TlsInspector {
 
+// Min/max TLS version recognized by the underlying TLS/SSL library.
+const unsigned Config::TLS_MIN_SUPPORTED_VERSION = TLS1_VERSION;
+const unsigned Config::TLS_MAX_SUPPORTED_VERSION = TLS1_3_VERSION;
+
 Config::Config(Stats::Scope& scope, uint32_t max_client_hello_size)
     : stats_{ALL_TLS_INSPECTOR_STATS(POOL_COUNTER_PREFIX(scope, "tls_inspector."))},
       ssl_ctx_(
@@ -35,6 +39,8 @@ Config::Config(Stats::Scope& scope, uint32_t max_client_hello_size)
                                      max_client_hello_size_, size_t(TLS_MAX_CLIENT_HELLO)));
   }
 
+  SSL_CTX_set_min_proto_version(ssl_ctx_.get(), TLS_MIN_SUPPORTED_VERSION);
+  SSL_CTX_set_max_proto_version(ssl_ctx_.get(), TLS_MAX_SUPPORTED_VERSION);
   SSL_CTX_set_options(ssl_ctx_.get(), SSL_OP_NO_TICKET);
   SSL_CTX_set_session_cache_mode(ssl_ctx_.get(), SSL_SESS_CACHE_OFF);
 

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -59,6 +59,8 @@ public:
   uint32_t maxClientHelloSize() const { return max_client_hello_size_; }
 
   static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
+  static const unsigned TLS_MIN_SUPPORTED_VERSION;
+  static const unsigned TLS_MAX_SUPPORTED_VERSION;
 
 private:
   TlsInspectorStats stats_;

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -83,12 +83,12 @@ public:
   void onCert();
 
 private:
+  std::vector<absl::string_view> getAlpnProtocols(const unsigned char* data, unsigned int len);
   ParseState parseClientHello(const void* data, size_t len);
   ParseState onRead();
   void onTimeout();
   void done(bool success);
   void onServername(absl::string_view name);
-  void setIstioApplicationProtocol();
 
   ConfigSharedPtr config_;
   Network::ListenerFilterCallbacks* cb_;
@@ -98,7 +98,6 @@ private:
   bssl::UniquePtr<SSL> ssl_;
   uint64_t read_{0};
   bool alpn_found_{false};
-  bool istio_protocol_required_{false};
   bool clienthello_success_{false};
 
   static thread_local uint8_t buf_[Config::TLS_MAX_CLIENT_HELLO];

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -158,33 +158,39 @@ ContextConfigImpl::ContextConfigImpl(
                                                 default_min_protocol_version)),
       max_protocol_version_(tlsVersionFromProto(config.tls_params().tls_maximum_protocol_version(),
                                                 default_max_protocol_version)) {
-  if (default_cvc_ && certificate_validation_context_provider_ != nullptr) {
-    // We need to validate combined certificate validation context.
-    // The default certificate validation context and dynamic certificate validation
-    // context could only contain partial fields, which is okay to fail the validation.
-    // But the combined certificate validation context should pass validation. If
-    // validation of combined certificate validation context fails,
-    // getCombinedValidationContextConfig() throws exception, validation_context_config_ will not
-    // get updated.
-    cvc_validation_callback_handle_ =
-        certificate_validation_context_provider_->addValidationCallback(
-            [this](const envoy::api::v2::auth::CertificateValidationContext& dynamic_cvc) {
-              getCombinedValidationContextConfig(dynamic_cvc);
-            });
+  if (certificate_validation_context_provider_ != nullptr) {
+    if (default_cvc_) {
+      // We need to validate combined certificate validation context.
+      // The default certificate validation context and dynamic certificate validation
+      // context could only contain partial fields, which is okay to fail the validation.
+      // But the combined certificate validation context should pass validation. If
+      // validation of combined certificate validation context fails,
+      // getCombinedValidationContextConfig() throws exception, validation_context_config_ will not
+      // get updated.
+      cvc_validation_callback_handle_ =
+          certificate_validation_context_provider_->addValidationCallback(
+              [this](const envoy::api::v2::auth::CertificateValidationContext& dynamic_cvc) {
+                getCombinedValidationContextConfig(dynamic_cvc);
+              });
+    }
+    // Load inlined, static or dynamic secret that's already available.
+    if (certificate_validation_context_provider_->secret() != nullptr) {
+      if (default_cvc_) {
+        validation_context_config_ =
+            getCombinedValidationContextConfig(*certificate_validation_context_provider_->secret());
+      } else {
+        validation_context_config_ = std::make_unique<Ssl::CertificateValidationContextConfigImpl>(
+            *certificate_validation_context_provider_->secret(), api_);
+      }
+    }
   }
-  // Load inline or static secret into tls_certificate_config_.
+  // Load inlined, static or dynamic secrets that are already available.
   if (!tls_certificate_providers_.empty()) {
     for (auto& provider : tls_certificate_providers_) {
       if (provider->secret() != nullptr) {
         tls_certificate_configs_.emplace_back(*provider->secret(), &factory_context, api_);
       }
     }
-  }
-  // Load inline or static secret into validation_context_config_.
-  if (certificate_validation_context_provider_ != nullptr &&
-      certificate_validation_context_provider_->secret() != nullptr) {
-    validation_context_config_ = std::make_unique<Ssl::CertificateValidationContextConfigImpl>(
-        *certificate_validation_context_provider_->secret(), api_);
   }
 }
 
@@ -347,12 +353,10 @@ ServerContextConfigImpl::ServerContextConfigImpl(
         [this](const envoy::api::v2::auth::TlsSessionTicketKeys& keys) {
           getSessionTicketKeys(keys);
         });
-  }
-
-  // Load inline or static secrets.
-  if (session_ticket_keys_provider_ != nullptr &&
-      session_ticket_keys_provider_->secret() != nullptr) {
-    session_ticket_keys_ = getSessionTicketKeys(*session_ticket_keys_provider_->secret());
+    // Load inlined, static or dynamic secret that's already available.
+    if (session_ticket_keys_provider_->secret() != nullptr) {
+      session_ticket_keys_ = getSessionTicketKeys(*session_ticket_keys_provider_->secret());
+    }
   }
 
   if ((config.common_tls_context().tls_certificates().size() +

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -13,6 +13,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::ContainerEq;
 using testing::Return;
 
 namespace Envoy {
@@ -34,6 +35,18 @@ protected:
   static void commitReservation(Buffer::RawSlice* iovecs, uint64_t num_iovecs, OwnedImpl& buffer) {
     buffer.commit(iovecs, num_iovecs);
   }
+
+  static void expectSlices(std::vector<std::vector<int>> buffer_list, OwnedImpl& buffer) {
+    if (buffer.usesOldImpl()) {
+      return;
+    }
+    const auto& buffer_slices = buffer.describeSlicesForTest();
+    for (uint64_t i = 0; i < buffer_slices.size(); i++) {
+      EXPECT_EQ(buffer_slices[i].data, buffer_list[i][0]);
+      EXPECT_EQ(buffer_slices[i].reservable, buffer_list[i][1]);
+      EXPECT_EQ(buffer_slices[i].capacity, buffer_list[i][2]);
+    }
+  }
 };
 
 INSTANTIATE_TEST_SUITE_P(OwnedImplTest, OwnedImplTest,
@@ -52,31 +65,49 @@ TEST_P(OwnedImplTest, AddBufferFragmentNoCleanup) {
 }
 
 TEST_P(OwnedImplTest, AddBufferFragmentWithCleanup) {
-  char input[] = "hello world";
-  BufferFragmentImpl frag(input, 11, [this](const void*, size_t, const BufferFragmentImpl*) {
-    release_callback_called_ = true;
-  });
+  std::string input(2048, 'a');
+  BufferFragmentImpl frag(
+      input.c_str(), input.size(),
+      [this](const void*, size_t, const BufferFragmentImpl*) { release_callback_called_ = true; });
   Buffer::OwnedImpl buffer;
   verifyImplementation(buffer);
   buffer.addBufferFragment(frag);
-  EXPECT_EQ(11, buffer.length());
+  EXPECT_EQ(2048, buffer.length());
 
-  buffer.drain(5);
-  EXPECT_EQ(6, buffer.length());
+  buffer.drain(2000);
+  EXPECT_EQ(48, buffer.length());
   EXPECT_FALSE(release_callback_called_);
 
-  buffer.drain(6);
+  buffer.drain(48);
+  EXPECT_EQ(0, buffer.length());
+  EXPECT_TRUE(release_callback_called_);
+}
+
+TEST_P(OwnedImplTest, AddEmptyFragment) {
+  char input[] = "hello world";
+  BufferFragmentImpl frag1(input, 11, [](const void*, size_t, const BufferFragmentImpl*) {});
+  BufferFragmentImpl frag2("", 0, [this](const void*, size_t, const BufferFragmentImpl*) {
+    release_callback_called_ = true;
+  });
+  Buffer::OwnedImpl buffer;
+  buffer.addBufferFragment(frag1);
+  EXPECT_EQ(11, buffer.length());
+
+  buffer.addBufferFragment(frag2);
+  EXPECT_EQ(11, buffer.length());
+
+  buffer.drain(11);
   EXPECT_EQ(0, buffer.length());
   EXPECT_TRUE(release_callback_called_);
 }
 
 TEST_P(OwnedImplTest, AddBufferFragmentDynamicAllocation) {
-  char input_stack[] = "hello world";
-  char* input = new char[11];
-  std::copy(input_stack, input_stack + 11, input);
+  std::string input_str(2048, 'a');
+  char* input = new char[2048];
+  std::copy(input_str.c_str(), input_str.c_str() + 11, input);
 
   BufferFragmentImpl* frag = new BufferFragmentImpl(
-      input, 11, [this](const void* data, size_t, const BufferFragmentImpl* frag) {
+      input, 2048, [this](const void* data, size_t, const BufferFragmentImpl* frag) {
         release_callback_called_ = true;
         delete[] static_cast<const char*>(data);
         delete frag;
@@ -85,9 +116,9 @@ TEST_P(OwnedImplTest, AddBufferFragmentDynamicAllocation) {
   Buffer::OwnedImpl buffer;
   verifyImplementation(buffer);
   buffer.addBufferFragment(*frag);
-  EXPECT_EQ(11, buffer.length());
+  EXPECT_EQ(2048, buffer.length());
 
-  buffer.drain(5);
+  buffer.drain(2042);
   EXPECT_EQ(6, buffer.length());
   EXPECT_FALSE(release_callback_called_);
 
@@ -97,10 +128,10 @@ TEST_P(OwnedImplTest, AddBufferFragmentDynamicAllocation) {
 }
 
 TEST_P(OwnedImplTest, AddOwnedBufferFragmentWithCleanup) {
-  char input[] = "hello world";
-  const size_t expected_length = sizeof(input) - 1;
+  std::string input(2048, 'a');
+  const size_t expected_length = input.size();
   auto frag = OwnedBufferFragmentImpl::create(
-      {input, expected_length},
+      {input.c_str(), expected_length},
       [this](const OwnedBufferFragmentImpl*) { release_callback_called_ = true; });
   Buffer::OwnedImpl buffer;
   verifyImplementation(buffer);
@@ -119,10 +150,10 @@ TEST_P(OwnedImplTest, AddOwnedBufferFragmentWithCleanup) {
 
 // Verify that OwnedBufferFragment work correctly when input buffer is allocated on the heap.
 TEST_P(OwnedImplTest, AddOwnedBufferFragmentDynamicAllocation) {
-  char input_stack[] = "hello world";
-  const size_t expected_length = sizeof(input_stack) - 1;
+  std::string input_str(2048, 'a');
+  const size_t expected_length = input_str.size();
   char* input = new char[expected_length];
-  std::copy(input_stack, input_stack + expected_length, input);
+  std::copy(input_str.c_str(), input_str.c_str() + expected_length, input);
 
   auto* frag = OwnedBufferFragmentImpl::create({input, expected_length},
                                                [this, input](const OwnedBufferFragmentImpl* frag) {
@@ -290,23 +321,27 @@ TEST_P(OwnedImplTest, Read) {
   EXPECT_TRUE(result.ok());
   EXPECT_EQ(0, result.rc_);
   EXPECT_EQ(0, buffer.length());
+  EXPECT_THAT(buffer.describeSlicesForTest(), testing::IsEmpty());
 
   EXPECT_CALL(os_sys_calls, readv(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{-1, 0}));
   result = buffer.read(io_handle, 100);
   EXPECT_EQ(Api::IoError::IoErrorCode::UnknownError, result.err_->getErrorCode());
   EXPECT_EQ(0, result.rc_);
   EXPECT_EQ(0, buffer.length());
+  EXPECT_THAT(buffer.describeSlicesForTest(), testing::IsEmpty());
 
   EXPECT_CALL(os_sys_calls, readv(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{-1, EAGAIN}));
   result = buffer.read(io_handle, 100);
   EXPECT_EQ(Api::IoError::IoErrorCode::Again, result.err_->getErrorCode());
   EXPECT_EQ(0, result.rc_);
   EXPECT_EQ(0, buffer.length());
+  EXPECT_THAT(buffer.describeSlicesForTest(), testing::IsEmpty());
 
   EXPECT_CALL(os_sys_calls, readv(_, _, _)).Times(0);
   result = buffer.read(io_handle, 0);
   EXPECT_EQ(0, result.rc_);
   EXPECT_EQ(0, buffer.length());
+  EXPECT_THAT(buffer.describeSlicesForTest(), testing::IsEmpty());
 }
 
 TEST_P(OwnedImplTest, ReserveCommit) {
@@ -354,38 +389,41 @@ TEST_P(OwnedImplTest, ReserveCommit) {
     // the last slice, and allow the buffer to use only one slice. This should result in the
     // creation of a new slice within the buffer.
     num_reserved = buffer.reserve(4096 - sizeof(OwnedSlice), iovecs, 1);
-    const void* slice2 = iovecs[0].mem_;
     EXPECT_EQ(1, num_reserved);
-    EXPECT_NE(slice1, slice2);
+    EXPECT_NE(slice1, iovecs[0].mem_);
     clearReservation(iovecs, num_reserved, buffer);
 
     // Request the same size reservation, but allow the buffer to use multiple slices. This
-    // should result in the buffer splitting the reservation between its last two slices.
+    // should result in the buffer creating a second slice and splitting the reservation between the
+    // last two slices.
     num_reserved = buffer.reserve(4096 - sizeof(OwnedSlice), iovecs, NumIovecs);
     EXPECT_EQ(2, num_reserved);
     EXPECT_EQ(slice1, iovecs[0].mem_);
-    EXPECT_EQ(slice2, iovecs[1].mem_);
     clearReservation(iovecs, num_reserved, buffer);
 
     // Request a reservation that too big to fit in the existing slices. This should result
     // in the creation of a third slice.
+    expectSlices({{1, 4055, 4056}}, buffer);
+    buffer.reserve(4096 - sizeof(OwnedSlice), iovecs, NumIovecs);
+    expectSlices({{1, 4055, 4056}, {0, 4056, 4056}}, buffer);
+    const void* slice2 = iovecs[1].mem_;
     num_reserved = buffer.reserve(8192, iovecs, NumIovecs);
+    expectSlices({{1, 4055, 4056}, {0, 4056, 4056}, {0, 4056, 4056}}, buffer);
     EXPECT_EQ(3, num_reserved);
     EXPECT_EQ(slice1, iovecs[0].mem_);
     EXPECT_EQ(slice2, iovecs[1].mem_);
-    const void* slice3 = iovecs[2].mem_;
     clearReservation(iovecs, num_reserved, buffer);
 
     // Append a fragment to the buffer, and then request a small reservation. The buffer
     // should make a new slice to satisfy the reservation; it cannot safely use any of
     // the previously seen slices, because they are no longer at the end of the buffer.
+    expectSlices({{1, 4055, 4056}}, buffer);
     buffer.addBufferFragment(fragment);
     EXPECT_EQ(13, buffer.length());
     num_reserved = buffer.reserve(1, iovecs, NumIovecs);
+    expectSlices({{1, 4055, 4056}, {12, 0, 12}, {0, 4056, 4056}}, buffer);
     EXPECT_EQ(1, num_reserved);
     EXPECT_NE(slice1, iovecs[0].mem_);
-    EXPECT_NE(slice2, iovecs[0].mem_);
-    EXPECT_NE(slice3, iovecs[0].mem_);
     commitReservation(iovecs, num_reserved, buffer);
     EXPECT_EQ(14, buffer.length());
   }
@@ -415,18 +453,20 @@ TEST_P(OwnedImplTest, ReserveCommitReuse) {
   num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
   EXPECT_EQ(2, num_reserved);
   const void* first_slice = iovecs[0].mem_;
-  const void* second_slice = iovecs[1].mem_;
   iovecs[0].len_ = 1;
+  expectSlices({{8000, 4248, 12248}, {0, 12248, 12248}}, buffer);
   buffer.commit(iovecs, 1);
   EXPECT_EQ(8001, buffer.length());
+  EXPECT_EQ(first_slice, iovecs[0].mem_);
+  // The second slice is now released because there's nothing in the second slice.
+  expectSlices({{8001, 4247, 12248}}, buffer);
 
-  // Reserve 16KB again, and check whether we get back the uncommitted
-  // second slice from the previous reservation.
+  // Reserve 16KB again.
   num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
+  expectSlices({{8001, 4247, 12248}, {0, 12248, 12248}}, buffer);
   EXPECT_EQ(2, num_reserved);
   EXPECT_EQ(static_cast<const uint8_t*>(first_slice) + 1,
             static_cast<const uint8_t*>(iovecs[0].mem_));
-  EXPECT_EQ(second_slice, iovecs[1].mem_);
 }
 
 TEST_P(OwnedImplTest, ReserveReuse) {
@@ -452,6 +492,66 @@ TEST_P(OwnedImplTest, ReserveReuse) {
   EXPECT_EQ(2, num_reserved);
   EXPECT_EQ(first_slice, iovecs[0].mem_);
   EXPECT_EQ(second_slice, iovecs[1].mem_);
+  expectSlices({{0, 12248, 12248}, {0, 8152, 8152}}, buffer);
+
+  // The remaining tests validate internal manipulations of the new slice
+  // implementation, so they're not valid for the old evbuffer implementation.
+  if (buffer.usesOldImpl()) {
+    return;
+  }
+
+  // Request a larger reservation, verify that the second entry is replaced with a block with a
+  // larger size.
+  num_reserved = buffer.reserve(30000, iovecs, NumIovecs);
+  const void* third_slice = iovecs[1].mem_;
+  EXPECT_EQ(2, num_reserved);
+  EXPECT_EQ(first_slice, iovecs[0].mem_);
+  EXPECT_EQ(12248, iovecs[0].len_);
+  EXPECT_NE(second_slice, iovecs[1].mem_);
+  EXPECT_EQ(30000 - iovecs[0].len_, iovecs[1].len_);
+  expectSlices({{0, 12248, 12248}, {0, 8152, 8152}, {0, 20440, 20440}}, buffer);
+
+  // Repeating a the reservation request for a smaller block returns the previous entry.
+  num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
+  EXPECT_EQ(2, num_reserved);
+  EXPECT_EQ(first_slice, iovecs[0].mem_);
+  EXPECT_EQ(second_slice, iovecs[1].mem_);
+  expectSlices({{0, 12248, 12248}, {0, 8152, 8152}, {0, 20440, 20440}}, buffer);
+
+  // Repeat the larger reservation notice that it doesn't match the prior reservation for 30000
+  // bytes.
+  num_reserved = buffer.reserve(30000, iovecs, NumIovecs);
+  EXPECT_EQ(2, num_reserved);
+  EXPECT_EQ(first_slice, iovecs[0].mem_);
+  EXPECT_EQ(12248, iovecs[0].len_);
+  EXPECT_NE(second_slice, iovecs[1].mem_);
+  EXPECT_NE(third_slice, iovecs[1].mem_);
+  EXPECT_EQ(30000 - iovecs[0].len_, iovecs[1].len_);
+  expectSlices({{0, 12248, 12248}, {0, 8152, 8152}, {0, 20440, 20440}, {0, 20440, 20440}}, buffer);
+
+  // Commit the most recent reservation and verify the representation.
+  buffer.commit(iovecs, num_reserved);
+  expectSlices({{12248, 0, 12248}, {0, 8152, 8152}, {0, 20440, 20440}, {17752, 2688, 20440}},
+               buffer);
+
+  // Do another reservation.
+  num_reserved = buffer.reserve(16384, iovecs, NumIovecs);
+  EXPECT_EQ(2, num_reserved);
+  expectSlices({{12248, 0, 12248},
+                {0, 8152, 8152},
+                {0, 20440, 20440},
+                {17752, 2688, 20440},
+                {0, 16344, 16344}},
+               buffer);
+
+  // And commit.
+  buffer.commit(iovecs, num_reserved);
+  expectSlices({{12248, 0, 12248},
+                {0, 8152, 8152},
+                {0, 20440, 20440},
+                {20440, 0, 20440},
+                {13696, 2648, 16344}},
+               buffer);
 }
 
 TEST_P(OwnedImplTest, Search) {
@@ -592,6 +692,29 @@ TEST_P(OwnedImplTest, ReserveZeroCommit) {
   ASSERT_EQ(::close(pipe_fds[1]), 0);
   ASSERT_EQ(previous_length, buf.search(data.data(), rc, previous_length));
   EXPECT_EQ("bbbbb", buf.toString().substr(0, 5));
+  expectSlices({{5, 0, 4056}, {1953, 2103, 4056}}, buf);
+}
+
+TEST_P(OwnedImplTest, ReadReserveAndCommit) {
+  BufferFragmentImpl frag("", 0, nullptr);
+  Buffer::OwnedImpl buf;
+  buf.add("bbbbb");
+
+  int pipe_fds[2] = {0, 0};
+  ASSERT_EQ(::pipe(pipe_fds), 0);
+  Network::IoSocketHandleImpl io_handle(pipe_fds[0]);
+  ASSERT_EQ(::fcntl(pipe_fds[0], F_SETFL, O_NONBLOCK), 0);
+  ASSERT_EQ(::fcntl(pipe_fds[1], F_SETFL, O_NONBLOCK), 0);
+
+  const uint32_t read_length = 32768;
+  std::string data = "e";
+  const ssize_t rc = ::write(pipe_fds[1], data.data(), data.size());
+  ASSERT_GT(rc, 0);
+  Api::IoCallUint64Result result = buf.read(io_handle, read_length);
+  ASSERT_EQ(result.rc_, static_cast<uint64_t>(rc));
+  ASSERT_EQ(::close(pipe_fds[1]), 0);
+  EXPECT_EQ("bbbbbe", buf.toString());
+  expectSlices({{6, 4050, 4056}}, buf);
 }
 
 TEST(OverflowDetectingUInt64, Arithmetic) {
@@ -605,6 +728,54 @@ TEST(OverflowDetectingUInt64, Arithmetic) {
   length += half;
   length += (half - 1); // length is now 2^64 - 1
   EXPECT_DEATH(length += 1, "overflow");
+}
+
+void TestBufferMove(uint64_t buffer1_length, uint64_t buffer2_length,
+                    uint64_t expected_slice_count) {
+  Buffer::OwnedImpl buffer1;
+  buffer1.add(std::string(buffer1_length, 'a'));
+  EXPECT_EQ(1, buffer1.getRawSlices(nullptr, 0));
+
+  Buffer::OwnedImpl buffer2;
+  buffer2.add(std::string(buffer2_length, 'b'));
+  EXPECT_EQ(1, buffer2.getRawSlices(nullptr, 0));
+
+  buffer1.move(buffer2);
+  EXPECT_EQ(expected_slice_count, buffer1.getRawSlices(nullptr, 0));
+  EXPECT_EQ(buffer1_length + buffer2_length, buffer1.length());
+  // Make sure `buffer2` was drained.
+  EXPECT_EQ(0, buffer2.length());
+}
+
+// Slice size large enough to prevent slice content from being coalesced into an existing slice
+constexpr uint64_t kLargeSliceSize = 2048;
+
+TEST(OwnedImplTest, MoveBuffersWithLargeSlices) {
+  // Large slices should not be coalesced together
+  TestBufferMove(kLargeSliceSize, kLargeSliceSize, 2);
+}
+
+TEST(OwnedImplTest, MoveBuffersWithSmallSlices) {
+  // Small slices should be coalesced together
+  TestBufferMove(1, 1, 1);
+}
+
+TEST(OwnedImplTest, MoveSmallSliceIntoLargeSlice) {
+  // Small slices should be coalesced with a large one
+  TestBufferMove(kLargeSliceSize, 1, 1);
+}
+
+TEST(OwnedImplTest, MoveLargeSliceIntoSmallSlice) {
+  // Large slice should NOT be coalesced into the small one
+  TestBufferMove(1, kLargeSliceSize, 2);
+}
+
+TEST(OwnedImplTest, MoveSmallSliceIntoNotEnoughFreeSpace) {
+  // Small slice will not be coalesced if a previous slice does not have enough free space
+  // Slice buffer sizes are allocated in 4Kb increments
+  // Make first slice have 127 of free space (it is actually less as there is small overhead of the
+  // OwnedSlice object) And second slice 128 bytes
+  TestBufferMove(4096 - 127, 128, 2);
 }
 
 } // namespace

--- a/test/common/buffer/zero_copy_input_stream_test.cc
+++ b/test/common/buffer/zero_copy_input_stream_test.cc
@@ -3,6 +3,7 @@
 
 #include "test/common/buffer/utility.h"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -39,7 +40,9 @@ TEST_P(ZeroCopyInputStreamTest, Next) {
 }
 
 TEST_P(ZeroCopyInputStreamTest, TwoSlices) {
-  Buffer::OwnedImpl buffer("efgh");
+  // Make content larger than 512 bytes so it would not be coalesced when
+  // moved into the stream_ buffer.
+  Buffer::OwnedImpl buffer(std::string(1024, 'A'));
   verifyImplementation(buffer);
 
   stream_.move(buffer);
@@ -48,8 +51,9 @@ TEST_P(ZeroCopyInputStreamTest, TwoSlices) {
   EXPECT_EQ(4, size_);
   EXPECT_EQ(0, memcmp(slice_data_.data(), data_, size_));
   EXPECT_TRUE(stream_.Next(&data_, &size_));
-  EXPECT_EQ(4, size_);
-  EXPECT_EQ(0, memcmp("efgh", data_, size_));
+  EXPECT_EQ(1024, size_);
+  EXPECT_THAT(absl::string_view(static_cast<const char*>(data_), size_),
+              testing::Each(testing::AllOf('A')));
 }
 
 TEST_P(ZeroCopyInputStreamTest, BackUp) {

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -24,6 +24,7 @@
 using testing::_;
 using testing::InSequence;
 using testing::Invoke;
+using testing::InvokeWithoutArgs;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
@@ -427,6 +428,92 @@ TEST_F(Http1ServerConnectionImplTest, BadRequestStartedStream) {
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", output);
 }
 
+TEST_F(Http1ServerConnectionImplTest, FloodProtection) {
+  initialize();
+
+  NiceMock<Http::MockStreamDecoder> decoder;
+  Buffer::OwnedImpl local_buffer;
+  // Read a request and send a response, without draining the response from the
+  // connection buffer. The first two should not cause problems.
+  for (int i = 0; i < 2; ++i) {
+    Http::StreamEncoder* response_encoder = nullptr;
+    EXPECT_CALL(callbacks_, newStream(_, _))
+        .WillOnce(Invoke([&](Http::StreamEncoder& encoder, bool) -> Http::StreamDecoder& {
+          response_encoder = &encoder;
+          return decoder;
+        }));
+
+    Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\n");
+    codec_->dispatch(buffer);
+    EXPECT_EQ(0U, buffer.length());
+
+    // In most tests the write output is serialized to a buffer here it is
+    // ignored to build up queued "end connection" sentinels.
+    EXPECT_CALL(connection_, write(_, _))
+        .Times(1)
+        .WillOnce(Invoke([&](Buffer::Instance& data, bool) -> void {
+          // Move the response out of data while preserving the buffer fragment sentinels.
+          local_buffer.move(data);
+        }));
+
+    TestHeaderMapImpl headers{{":status", "200"}};
+    response_encoder->encodeHeaders(headers, true);
+  }
+
+  // Trying to shove a third response in the queue should trigger flood protection.
+  {
+    Http::StreamEncoder* response_encoder = nullptr;
+    EXPECT_CALL(callbacks_, newStream(_, _))
+        .WillOnce(Invoke([&](Http::StreamEncoder& encoder, bool) -> Http::StreamDecoder& {
+          response_encoder = &encoder;
+          return decoder;
+        }));
+
+    Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\n");
+    codec_->dispatch(buffer);
+
+    TestHeaderMapImpl headers{{":status", "200"}};
+    EXPECT_THROW_WITH_MESSAGE(response_encoder->encodeHeaders(headers, true), FrameFloodException,
+                              "Too many responses queued.");
+    EXPECT_EQ(1, store_.counter("http1.response_flood").value());
+  }
+}
+
+TEST_F(Http1ServerConnectionImplTest, FloodProtectionOff) {
+  TestScopedRuntime scoped_runtime;
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.http1_flood_protection", "false"}});
+  initialize();
+
+  NiceMock<Http::MockStreamDecoder> decoder;
+  Buffer::OwnedImpl local_buffer;
+  // With flood protection off, many responses can be queued up.
+  for (int i = 0; i < 4; ++i) {
+    Http::StreamEncoder* response_encoder = nullptr;
+    EXPECT_CALL(callbacks_, newStream(_, _))
+        .WillOnce(Invoke([&](Http::StreamEncoder& encoder, bool) -> Http::StreamDecoder& {
+          response_encoder = &encoder;
+          return decoder;
+        }));
+
+    Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\n");
+    codec_->dispatch(buffer);
+    EXPECT_EQ(0U, buffer.length());
+
+    // In most tests the write output is serialized to a buffer here it is
+    // ignored to build up queued "end connection" sentinels.
+    EXPECT_CALL(connection_, write(_, _))
+        .Times(1)
+        .WillOnce(Invoke([&](Buffer::Instance& data, bool) -> void {
+          // Move the response out of data while preserving the buffer fragment sentinels.
+          local_buffer.move(data);
+        }));
+
+    TestHeaderMapImpl headers{{":status", "200"}};
+    response_encoder->encodeHeaders(headers, true);
+  }
+}
+
 TEST_F(Http1ServerConnectionImplTest, HostHeaderTranslation) {
   initialize();
 
@@ -754,7 +841,13 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedResponse) {
   EXPECT_EQ(0U, buffer.length());
 
   std::string output;
-  ON_CALL(connection_, write(_, _)).WillByDefault(AddBufferToString(&output));
+  ON_CALL(connection_, write(_, _)).WillByDefault(Invoke([&output](Buffer::Instance& data, bool) {
+    // Verify that individual writes into the codec's output buffer were coalesced into a single
+    // slice
+    ASSERT_EQ(1, data.getRawSlices(nullptr, 0));
+    output.append(data.toString());
+    data.drain(data.length());
+  }));
 
   TestHeaderMapImpl headers{{":status", "200"}};
   response_encoder->encodeHeaders(headers, false);

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -136,6 +136,11 @@ protected:
   }
 
   void disconnect(bool wait_for_remote_close) {
+    if (client_write_buffer_) {
+      EXPECT_CALL(*client_write_buffer_, drain(_))
+          .Times(AnyNumber())
+          .WillOnce(Invoke([&](uint64_t size) -> void { client_write_buffer_->baseDrain(size); }));
+    }
     EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::LocalClose));
     client_connection_->close(ConnectionCloseType::NoFlush);
     if (wait_for_remote_close) {
@@ -810,8 +815,6 @@ TEST_P(ConnectionImplTest, WriteWithWatermarks) {
   // call to write() will succeed, bringing the connection back under the low watermark.
   EXPECT_CALL(*client_write_buffer_, write(_))
       .WillOnce(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackWrites));
-  EXPECT_CALL(*client_write_buffer_, drain(_))
-      .WillOnce(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackDrains));
   EXPECT_CALL(client_callbacks_, onBelowWriteBufferLowWatermark()).Times(1);
 
   disconnect(true);
@@ -889,6 +892,7 @@ TEST_P(ConnectionImplTest, WatermarkFuzzing) {
     dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
   }
 
+  EXPECT_CALL(client_callbacks_, onBelowWriteBufferLowWatermark()).Times(AnyNumber());
   disconnect(true);
 }
 

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -32,12 +32,14 @@ TEST(Context, EmptyHeadersAttributes) {
 
 TEST(Context, RequestAttributes) {
   NiceMock<StreamInfo::MockStreamInfo> info;
+  NiceMock<StreamInfo::MockStreamInfo> empty_info;
   Http::TestHeaderMapImpl header_map{
       {":method", "POST"},           {":scheme", "http"},      {":path", "/meow?yes=1"},
       {":authority", "kittens.com"}, {"referer", "dogs.com"},  {"user-agent", "envoy-mobile"},
       {"content-length", "10"},      {"x-request-id", "blah"},
   };
   RequestWrapper request(&header_map, info);
+  RequestWrapper empty_request(nullptr, empty_info);
 
   EXPECT_CALL(info, bytesReceived()).WillRepeatedly(Return(10));
   // "2018-04-03T23:06:09.123Z".
@@ -66,6 +68,12 @@ TEST(Context, RequestAttributes) {
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("http", value.value().StringOrDie().value());
   }
+
+  {
+    auto value = empty_request[CelValue::CreateString(Scheme)];
+    EXPECT_FALSE(value.has_value());
+  }
+
   {
     auto value = request[CelValue::CreateString(Host)];
     EXPECT_TRUE(value.has_value());
@@ -131,6 +139,14 @@ TEST(Context, RequestAttributes) {
   }
 
   {
+    auto value = empty_request[CelValue::CreateString(TotalSize)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsInt64());
+    // this includes the headers size
+    EXPECT_EQ(0, value.value().Int64OrDie());
+  }
+
+  {
     auto value = request[CelValue::CreateString(Time)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsTimestamp());
@@ -187,11 +203,13 @@ TEST(Context, RequestFallbackAttributes) {
 
 TEST(Context, ResponseAttributes) {
   NiceMock<StreamInfo::MockStreamInfo> info;
+  NiceMock<StreamInfo::MockStreamInfo> empty_info;
   const std::string header_name = "test-header";
   const std::string trailer_name = "test-trailer";
   Http::TestHeaderMapImpl header_map{{header_name, "a"}};
   Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}};
   ResponseWrapper response(&header_map, &trailer_map, info);
+  ResponseWrapper empty_response(nullptr, nullptr, empty_info);
 
   EXPECT_CALL(info, responseCode()).WillRepeatedly(Return(404));
   EXPECT_CALL(info, bytesSent()).WillRepeatedly(Return(123));
@@ -212,6 +230,21 @@ TEST(Context, ResponseAttributes) {
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(123, value.value().Int64OrDie());
+  }
+
+  {
+    auto value = response[CelValue::CreateString(TotalSize)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsInt64());
+    EXPECT_EQ(148, value.value().Int64OrDie());
+  }
+
+
+  {
+    auto value = empty_response[CelValue::CreateString(TotalSize)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsInt64());
+    EXPECT_EQ(0, value.value().Int64OrDie());
   }
 
   {
@@ -251,6 +284,7 @@ TEST(Context, ResponseAttributes) {
     ASSERT_TRUE(header.value().IsString());
     EXPECT_EQ("b", header.value().StringOrDie().value());
   }
+
   {
     auto value = response[CelValue::CreateString(Flags)];
     EXPECT_TRUE(value.has_value());

--- a/test/extensions/filters/listener/tls_inspector/BUILD
+++ b/test/extensions/filters/listener/tls_inspector/BUILD
@@ -51,6 +51,5 @@ envoy_cc_library(
     ],
     deps = [
         "//source/common/common:assert_lib",
-        "//source/extensions/filters/listener/tls_inspector:openssl_impl_lib",
     ],
 )

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -66,8 +66,9 @@ public:
 };
 
 static void BM_TlsInspector(benchmark::State& state) {
-  NiceMock<FastMockOsSysCalls> os_sys_calls(
-      Envoy::Extensions::ListenerFilters::TlsInspector::Test::generateClientHello("example.com", "\x02h2\x08http/1.1"));
+  NiceMock<FastMockOsSysCalls> os_sys_calls(Tls::Test::generateClientHello(
+      Config::TLS_MIN_SUPPORTED_VERSION, Config::TLS_MAX_SUPPORTED_VERSION, "example.com",
+      "\x02h2\x08http/1.1"));
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls};
   NiceMock<Stats::MockStore> store;
   ConfigSharedPtr cfg(std::make_shared<Config>(store));

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -115,7 +115,6 @@ TEST_P(TlsInspectorTest, SniRegistered) {
             return Api::SysCallSizeResult{ssize_t(client_hello.size()), 0};
           }));
   EXPECT_CALL(socket_, setRequestedServerName(Eq(servername)));
-  // Not valid for ALPN "istio" application protocol hack for openssl
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(cb_, continueFilterChain(true));
@@ -201,7 +200,6 @@ TEST_P(TlsInspectorTest, NoExtensions) {
             return Api::SysCallSizeResult{ssize_t(client_hello.size()), 0};
           }));
   EXPECT_CALL(socket_, setRequestedServerName(_)).Times(0);
-  // 0 times not valid for ALPN "istio" application protocol hack for openssl
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(cb_, continueFilterChain(true));

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -116,7 +116,7 @@ TEST_P(TlsInspectorTest, SniRegistered) {
           }));
   EXPECT_CALL(socket_, setRequestedServerName(Eq(servername)));
   // Not valid for ALPN "istio" application protocol hack for openssl
-  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(1);
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(cb_, continueFilterChain(true));
   file_event_callback_(Event::FileReadyType::Read);
@@ -202,7 +202,7 @@ TEST_P(TlsInspectorTest, NoExtensions) {
           }));
   EXPECT_CALL(socket_, setRequestedServerName(_)).Times(0);
   // 0 times not valid for ALPN "istio" application protocol hack for openssl
-  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(1);
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(cb_, continueFilterChain(true));
   file_event_callback_(Event::FileReadyType::Read);

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -27,7 +27,7 @@ namespace ListenerFilters {
 namespace TlsInspector {
 namespace {
 
-class TlsInspectorTest : public testing::Test {
+class TlsInspectorTest : public testing::TestWithParam<std::tuple<uint16_t, uint16_t>> {
 public:
   TlsInspectorTest()
       : cfg_(std::make_shared<Config>(store_)),
@@ -68,14 +68,22 @@ public:
   Network::IoHandlePtr io_handle_;
 };
 
+INSTANTIATE_TEST_SUITE_P(TlsProtocolVersions, TlsInspectorTest,
+                         testing::Values(std::make_tuple(Config::TLS_MIN_SUPPORTED_VERSION,
+                                                         Config::TLS_MAX_SUPPORTED_VERSION),
+                                         std::make_tuple(TLS1_VERSION, TLS1_VERSION),
+                                         std::make_tuple(TLS1_1_VERSION, TLS1_1_VERSION),
+                                         std::make_tuple(TLS1_2_VERSION, TLS1_2_VERSION),
+                                         std::make_tuple(TLS1_3_VERSION, TLS1_3_VERSION)));
+
 // Test that an exception is thrown for an invalid value for max_client_hello_size
-TEST_F(TlsInspectorTest, MaxClientHelloSize) {
+TEST_P(TlsInspectorTest, MaxClientHelloSize) {
   EXPECT_THROW_WITH_MESSAGE(Config(store_, Config::TLS_MAX_CLIENT_HELLO + 1), EnvoyException,
                             "max_client_hello_size of 65537 is greater than maximum of 65536.");
 }
 
 // Test that the filter detects Closed events and terminates.
-TEST_F(TlsInspectorTest, ConnectionClosed) {
+TEST_P(TlsInspectorTest, ConnectionClosed) {
   init();
   EXPECT_CALL(cb_, continueFilterChain(false));
   file_event_callback_(Event::FileReadyType::Closed);
@@ -83,7 +91,7 @@ TEST_F(TlsInspectorTest, ConnectionClosed) {
 }
 
 // Test that the filter detects detects read errors.
-TEST_F(TlsInspectorTest, ReadError) {
+TEST_P(TlsInspectorTest, ReadError) {
   init();
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK)).WillOnce(InvokeWithoutArgs([]() {
     return Api::SysCallSizeResult{ssize_t(-1), ENOTSUP};
@@ -94,10 +102,11 @@ TEST_F(TlsInspectorTest, ReadError) {
 }
 
 // Test that a ClientHello with an SNI value causes the correct name notification.
-TEST_F(TlsInspectorTest, SniRegistered) {
+TEST_P(TlsInspectorTest, SniRegistered) {
   init();
   const std::string servername("example.com");
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(servername, "");
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
+      std::get<0>(GetParam()), std::get<1>(GetParam()), servername, "");
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
       .WillOnce(
           Invoke([&client_hello](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
@@ -117,11 +126,12 @@ TEST_F(TlsInspectorTest, SniRegistered) {
 }
 
 // Test that a ClientHello with an ALPN value causes the correct name notification.
-TEST_F(TlsInspectorTest, AlpnRegistered) {
+TEST_P(TlsInspectorTest, AlpnRegistered) {
   init();
   const std::vector<absl::string_view> alpn_protos = {absl::string_view("h2"),
                                                       absl::string_view("http/1.1")};
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello("", "\x02h2\x08http/1.1");
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
+      std::get<0>(GetParam()), std::get<1>(GetParam()), "", "\x02h2\x08http/1.1");
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
       .WillOnce(
           Invoke([&client_hello](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
@@ -140,11 +150,12 @@ TEST_F(TlsInspectorTest, AlpnRegistered) {
 }
 
 // Test with the ClientHello spread over multiple socket reads.
-TEST_F(TlsInspectorTest, MultipleReads) {
+TEST_P(TlsInspectorTest, MultipleReads) {
   init();
   const std::vector<absl::string_view> alpn_protos = {absl::string_view("h2")};
   const std::string servername("example.com");
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(servername, "\x02h2");
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
+      std::get<0>(GetParam()), std::get<1>(GetParam()), servername, "\x02h2");
   {
     InSequence s;
     EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
@@ -178,9 +189,10 @@ TEST_F(TlsInspectorTest, MultipleReads) {
 }
 
 // Test that the filter correctly handles a ClientHello with no extensions present.
-TEST_F(TlsInspectorTest, NoExtensions) {
+TEST_P(TlsInspectorTest, NoExtensions) {
   init();
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello("", "");
+  std::vector<uint8_t> client_hello =
+      Tls::Test::generateClientHello(std::get<0>(GetParam()), std::get<1>(GetParam()), "", "");
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
       .WillOnce(
           Invoke([&client_hello](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
@@ -201,10 +213,11 @@ TEST_F(TlsInspectorTest, NoExtensions) {
 
 // Test that the filter fails if the ClientHello is larger than the
 // maximum allowed size.
-TEST_F(TlsInspectorTest, ClientHelloTooBig) {
+TEST_P(TlsInspectorTest, ClientHelloTooBig) {
   const size_t max_size = 50;
   cfg_ = std::make_shared<Config>(store_, max_size);
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello("example.com", "");
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
+      std::get<0>(GetParam()), std::get<1>(GetParam()), "example.com", "");
   ASSERT(client_hello.size() > max_size);
   init();
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
@@ -220,7 +233,7 @@ TEST_F(TlsInspectorTest, ClientHelloTooBig) {
 }
 
 // Test that the filter fails on non-SSL data
-TEST_F(TlsInspectorTest, NotSsl) {
+TEST_P(TlsInspectorTest, NotSsl) {
   init();
   std::vector<uint8_t> data;
 
@@ -238,7 +251,7 @@ TEST_F(TlsInspectorTest, NotSsl) {
   EXPECT_EQ(1, cfg_->stats().tls_not_found_.value());
 }
 
-TEST_F(TlsInspectorTest, InlineReadSucceed) {
+TEST_P(TlsInspectorTest, InlineReadSucceed) {
   filter_ = std::make_unique<Filter>(cfg_);
 
   EXPECT_CALL(cb_, socket()).WillRepeatedly(ReturnRef(socket_));
@@ -246,7 +259,8 @@ TEST_F(TlsInspectorTest, InlineReadSucceed) {
   EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(ReturnRef(*io_handle_));
   const std::vector<absl::string_view> alpn_protos = {absl::string_view("h2")};
   const std::string servername("example.com");
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(servername, "\x02h2");
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
+      std::get<0>(GetParam()), std::get<1>(GetParam()), servername, "\x02h2");
 
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
       .WillOnce(Invoke(

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.cc
@@ -2,8 +2,6 @@
 
 #include "common/common/assert.h"
 
-#include "extensions/filters/listener/tls_inspector/openssl_impl.h"
-
 #include "bssl_wrapper/bssl_wrapper.h"
 #include "openssl/ssl.h"
 
@@ -12,9 +10,9 @@ namespace Tls {
 namespace Test {
 
 std::vector<uint8_t> generateClientHello(uint16_t tls_min_version, uint16_t tls_max_version,
-                                        const std::string& sni_name, const std::string& alpn) {
-  bssl::UniquePtr<SSL_CTX> ctx(
-      SSL_CTX_new(Envoy::Extensions::ListenerFilters::TlsInspector::TLS_with_buffers_method()));
+		                         const std::string& sni_name, const std::string& alpn) {
+  // TODO (dmitri-d) add an implementation of TLS_with_buffers_method to bssl_wrapper
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
 
   SSL_CTX_set_min_proto_version(ctx.get(), tls_min_version);
   SSL_CTX_set_max_proto_version(ctx.get(), tls_max_version);

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.cc
@@ -11,12 +11,13 @@ namespace Envoy {
 namespace Tls {
 namespace Test {
 
-std::vector<uint8_t> generateClientHello(const std::string& sni_name, const std::string& alpn) {
+std::vector<uint8_t> generateClientHello(uint16_t tls_min_version, uint16_t tls_max_version,
+                                        const std::string& sni_name, const std::string& alpn) {
   bssl::UniquePtr<SSL_CTX> ctx(
       SSL_CTX_new(Envoy::Extensions::ListenerFilters::TlsInspector::TLS_with_buffers_method()));
 
-  const long flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION;
-  SSL_CTX_set_options(ctx.get(), flags);
+  SSL_CTX_set_min_proto_version(ctx.get(), tls_min_version);
+  SSL_CTX_set_max_proto_version(ctx.get(), tls_max_version);
 
   bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
 

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.h
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.h
@@ -9,12 +9,15 @@ namespace Test {
 
 /**
  * Generate a TLS ClientHello in wire-format.
+ * @param tls_min_version Minimum supported TLS version to advertise.
+ * @param tls_max_version Maximum supported TLS version to advertise.
  * @param sni_name The name to include as a Server Name Indication.
  *                 No SNI extension is added if sni_name is empty.
  * @param alpn Protocol(s) list in the wire-format (i.e. 8-bit length-prefixed string) to advertise
  *             in Application-Layer Protocol Negotiation. No ALPN is advertised if alpn is empty.
  */
-std::vector<uint8_t> generateClientHello(const std::string& sni_name, const std::string& alpn);
+std::vector<uint8_t> generateClientHello(uint16_t tls_min_version, uint16_t tls_max_version,
+                                         const std::string& sni_name, const std::string& alpn);
 
 } // namespace Test
 } // namespace Tls

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -3979,7 +3979,7 @@ protected:
     EXPECT_CALL(*client_write_buffer, move(_))
         .WillRepeatedly(DoAll(AddBufferToStringWithoutDraining(&data_written),
                               Invoke(client_write_buffer, &MockWatermarkBuffer::baseMove)));
-    EXPECT_CALL(*client_write_buffer, drain(_)).WillOnce(Invoke([&](uint64_t n) -> void {
+    EXPECT_CALL(*client_write_buffer, drain(_)).Times(2).WillOnce(Invoke([&](uint64_t n) -> void {
       client_write_buffer->baseDrain(n);
       dispatcher_->exit();
     }));

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -261,8 +261,9 @@ TEST_P(IntegrationAdminTest, Admin) {
   case Http::CodecClient::Type::HTTP1:
     EXPECT_EQ("   Count Lookup\n"
               "       1 http1.metadata_not_supported_error\n"
+              "       1 http1.response_flood\n"
               "\n"
-              "total: 1\n",
+              "total: 2\n",
               response->body());
     break;
   case Http::CodecClient::Type::HTTP2:

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -959,4 +959,53 @@ TEST_P(UpstreamEndpointIntegrationTest, TestUpstreamEndpointAddress) {
                Network::Test::getLoopbackAddressString(GetParam()).c_str());
 }
 
+// Send continuous pipelined requests while not reading responses, to check
+// HTTP/1.1 response flood protection.
+TEST_P(IntegrationTest, TestFlood) {
+  initialize();
+
+  // Set up a raw connection to easily send requests without reading responses.
+  Network::ClientConnectionPtr raw_connection = makeClientConnection(lookupPort("http"));
+  raw_connection->connect();
+
+  // Read disable so responses will queue up.
+  uint32_t bytes_to_send = 0;
+  raw_connection->readDisable(true);
+  // Track locally queued bytes, to make sure the outbound client queue doesn't back up.
+  raw_connection->addBytesSentCallback([&](uint64_t bytes) { bytes_to_send -= bytes; });
+
+  // Keep sending requests until flood protection kicks in and kills the connection.
+  while (raw_connection->state() == Network::Connection::State::Open) {
+    // These requests are missing the host header, so will provoke an internally generated error
+    // response from Envoy.
+    Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\nGET / HTTP/1.1\r\n\r\nGET / HTTP/1.1\r\n\r\n");
+    bytes_to_send += buffer.length();
+    raw_connection->write(buffer, false);
+    // Loop until all bytes are sent.
+    while (bytes_to_send > 0 && raw_connection->state() == Network::Connection::State::Open) {
+      raw_connection->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+    }
+  }
+
+  // Verify the connection was closed due to flood protection.
+  EXPECT_EQ(1, test_server_->counter("http1.response_flood")->value());
+}
+
+// Make sure flood protection doesn't kick in with many requests sent serially.
+TEST_P(IntegrationTest, TestManyBadRequests) {
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  Http::TestHeaderMapImpl bad_request{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}};
+
+  for (int i = 0; i < 1; ++i) {
+    IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(bad_request);
+    response->waitForEndStream();
+    ASSERT_TRUE(response->complete());
+    EXPECT_THAT(response->headers(), HttpStatusIs("400"));
+  }
+  EXPECT_EQ(0, test_server_->counter("http1.response_flood")->value());
+}
+
 } // namespace Envoy

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -10,6 +10,7 @@
 
 #include "extensions/transport_sockets/tls/context_config_impl.h"
 #include "extensions/transport_sockets/tls/context_manager_impl.h"
+#include "extensions/transport_sockets/tls/ssl_socket.h"
 
 #include "test/common/grpc/grpc_client_integration.h"
 #include "test/config/integration/certs/clientcert_hash.h"
@@ -257,21 +258,7 @@ public:
           TestEnvironment::runfilesPath("test/config/integration/certs/servercert.pem"));
       tls_certificate->mutable_private_key()->set_filename(
           TestEnvironment::runfilesPath("test/config/integration/certs/serverkey.pem"));
-
-      if (use_combined_validation_context_) {
-        // Modify the listener context validation type to use combined certificate validation
-        // context.
-        auto* combined_config = common_tls_context->mutable_combined_validation_context();
-        auto* default_validation_context = combined_config->mutable_default_validation_context();
-        default_validation_context->add_verify_certificate_hash(TEST_CLIENT_CERT_HASH);
-        auto* secret_config = combined_config->mutable_validation_context_sds_secret_config();
-        setUpSdsConfig(secret_config, validation_secret_);
-      } else {
-        // Modify the listener context validation type to use dynamic certificate validation
-        // context.
-        auto* secret_config = common_tls_context->mutable_validation_context_sds_secret_config();
-        setUpSdsConfig(secret_config, validation_secret_);
-      }
+      setUpSdsValidationContext(common_tls_context);
       transport_socket->set_name("envoy.transport_sockets.tls");
       transport_socket->mutable_typed_config()->PackFrom(tls_context);
 
@@ -280,16 +267,89 @@ public:
       sds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
       sds_cluster->set_name("sds_cluster");
       sds_cluster->mutable_http2_protocol_options();
+
+      envoy::api::v2::auth::UpstreamTlsContext upstream_tls_context;
+      if (share_validation_secret_) {
+        // Configure static cluster with SDS config referencing "validation_secret",
+        // which is going to be processed before LDS resources.
+        ASSERT(use_lds_);
+        setUpSdsValidationContext(upstream_tls_context.mutable_common_tls_context());
+      }
+      // Enable SSL/TLS with a client certificate in the first cluster.
+      auto* upstream_tls_certificate =
+          upstream_tls_context.mutable_common_tls_context()->add_tls_certificates();
+      upstream_tls_certificate->mutable_certificate_chain()->set_filename(
+          TestEnvironment::runfilesPath("test/config/integration/certs/clientcert.pem"));
+      upstream_tls_certificate->mutable_private_key()->set_filename(
+          TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
+      auto* upstream_transport_socket =
+          bootstrap.mutable_static_resources()->mutable_clusters(0)->mutable_transport_socket();
+      upstream_transport_socket->set_name("envoy.transport_sockets.tls");
+      upstream_transport_socket->mutable_typed_config()->PackFrom(upstream_tls_context);
     });
 
     HttpIntegrationTest::initialize();
+    registerTestServerPorts({"http"});
     client_ssl_ctx_ = createClientSslTransportSocketFactory({}, context_manager_, *api_);
   }
 
+  void setUpSdsValidationContext(envoy::api::v2::auth::CommonTlsContext* common_tls_context) {
+    if (use_combined_validation_context_) {
+      // Modify the listener context validation type to use combined certificate validation
+      // context.
+      auto* combined_config = common_tls_context->mutable_combined_validation_context();
+      auto* default_validation_context = combined_config->mutable_default_validation_context();
+      default_validation_context->add_verify_certificate_hash(TEST_CLIENT_CERT_HASH);
+      auto* secret_config = combined_config->mutable_validation_context_sds_secret_config();
+      setUpSdsConfig(secret_config, validation_secret_);
+    } else {
+      // Modify the listener context validation type to use dynamic certificate validation
+      // context.
+      auto* secret_config = common_tls_context->mutable_validation_context_sds_secret_config();
+      setUpSdsConfig(secret_config, validation_secret_);
+    }
+  }
+
+  void createUpstreams() override {
+    // Fake upstream with SSL/TLS for the first cluster.
+    fake_upstreams_.emplace_back(new FakeUpstream(
+        createUpstreamSslContext(), 0, FakeHttpConnection::Type::HTTP1, version_, timeSystem()));
+    create_xds_upstream_ = true;
+  }
+
+  Network::TransportSocketFactoryPtr createUpstreamSslContext() {
+    envoy::api::v2::auth::DownstreamTlsContext tls_context;
+    auto* common_tls_context = tls_context.mutable_common_tls_context();
+    auto* tls_certificate = common_tls_context->add_tls_certificates();
+    tls_certificate->mutable_certificate_chain()->set_filename(
+        TestEnvironment::runfilesPath("test/config/integration/certs/clientcert.pem"));
+    tls_certificate->mutable_private_key()->set_filename(
+        TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
+
+    auto cfg = std::make_unique<Extensions::TransportSockets::Tls::ServerContextConfigImpl>(
+        tls_context, factory_context_);
+    static Stats::Scope* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
+    return std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
+        std::move(cfg), context_manager_, *upstream_stats_store, std::vector<std::string>{});
+  }
+
+  void TearDown() override {
+    cleanUpXdsConnection();
+
+    client_ssl_ctx_.reset();
+    cleanupUpstreamAndDownstream();
+    codec_client_.reset();
+
+    test_server_.reset();
+    fake_upstreams_.clear();
+  }
+
   void enableCombinedValidationContext(bool enable) { use_combined_validation_context_ = enable; }
+  void shareValidationSecret(bool share) { share_validation_secret_ = share; }
 
 private:
   bool use_combined_validation_context_{false};
+  bool share_validation_secret_{false};
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, SdsDynamicDownstreamCertValidationContextTest,
@@ -320,6 +380,53 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, CombinedCertValidationCont
     sendSdsResponse(getCvcSecretWithOnlyTrustedCa());
   };
   initialize();
+
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection();
+  };
+  testRouterHeaderOnlyRequestAndResponse(&creator);
+}
+
+// A test that verifies that both: static cluster and LDS listener are updated when using
+// the same verification secret (standalone validation context) from the SDS server.
+TEST_P(SdsDynamicDownstreamCertValidationContextTest, BasicWithSharedSecret) {
+  shareValidationSecret(true);
+  on_server_init_function_ = [this]() {
+    createSdsStream(*(fake_upstreams_[1]));
+    sendSdsResponse(getCvcSecret());
+  };
+  initialize();
+
+  // Wait for "ssl_context_updated_by_sds" counters to indicate that both resources
+  // depending on the verification_secret were updated.
+  test_server_->waitForCounterGe(
+      "cluster.cluster_0.client_ssl_socket_factory.ssl_context_update_by_sds", 1);
+  test_server_->waitForCounterGe(
+      listenerStatPrefix("server_ssl_socket_factory.ssl_context_update_by_sds"), 1);
+
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection();
+  };
+  testRouterHeaderOnlyRequestAndResponse(&creator);
+}
+
+// A test that verifies that both: static cluster and LDS listener are updated when using
+// the same verification secret (combined validation context) from the SDS server.
+TEST_P(SdsDynamicDownstreamCertValidationContextTest, CombinedValidationContextWithSharedSecret) {
+  enableCombinedValidationContext(true);
+  shareValidationSecret(true);
+  on_server_init_function_ = [this]() {
+    createSdsStream(*(fake_upstreams_[1]));
+    sendSdsResponse(getCvcSecretWithOnlyTrustedCa());
+  };
+  initialize();
+
+  // Wait for "ssl_context_updated_by_sds" counters to indicate that both resources
+  // depending on the verification_secret were updated.
+  test_server_->waitForCounterGe(
+      "cluster.cluster_0.client_ssl_socket_factory.ssl_context_update_by_sds", 1);
+  test_server_->waitForCounterGe(
+      listenerStatPrefix("server_ssl_socket_factory.ssl_context_update_by_sds"), 1);
 
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();


### PR DESCRIPTION
This PR 
* brings maistra-1.1 branch up to date with changes in upstream 1.4.6 
* updates bssl_wrapper depedency to latest
* resolves alpn issues in tls_inspector

I decided to postpone moving code accessing SSL struct internal into bssl_wrapper until the next release, mostly to simplify and speed up 1.1 release.  