### PR TITLE
Fixes MAISTRA-1299: fix ASSERT failure and infinite loop when attempt…

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -293,10 +293,6 @@ void ConnectionImpl::enableHalfClose(bool enabled) {
 void ConnectionImpl::readDisable(bool disable) {
   ASSERT(state() == State::Open);
   ASSERT(file_event_ != nullptr);
-  if (state() != State::Open || file_event_ == nullptr) {
-    // If readDisable is called on a closed connection in error, do not crash.
-    return;
-  }
 
   ENVOY_CONN_LOG(trace, "readDisable: enabled={} disable={} state={}", *this, read_enabled_,
                  disable, static_cast<int>(state()));


### PR DESCRIPTION
…ing to unset readDisable state on a closed connection, part 2

Fixed a test failure (here: https://github.com/Maistra/envoy/blob/maistra-1.1/test/common/network/connection_impl_test.cc#L603) that showed up when ```NDEBUG``` macro was set to false