### PR TITLE
MAISTRA-1279: Do not print OpenSSL version

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -366,7 +366,7 @@ envoy_cc_library(
         # This is done so that the definitions linked via the linkstamp rule don't cause collisions.
         "//conditions:default": [":generate_version_linkstamp_empty"],
     }),
-    copts = ["-DENVOY_SSL_VERSION=\\\"OpenSSL_1.1.1d\\\""],
+    copts = ["-DENVOY_SSL_VERSION=\\\"OpenSSL\\\""],
     linkstamp = "version_linkstamp.cc",
     strip_include_prefix = select({
         "//bazel:manual_stamp": "lib",


### PR DESCRIPTION
Because:
- The runtime version could be different than the version used to
  build. This is a dinamically linked library.
- It's more secure not to print the version.
