### PR TITLE
Fixes MAISTRA-1564: errno is now being logged when SSL_read() fails

### DIFF
--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -116,7 +116,7 @@ private:
   ReadResult sslReadIntoSlice(Buffer::RawSlice& slice);
 
   Network::PostIoAction doHandshake();
-  void drainErrorQueue();
+  void drainErrorQueue(const bool show_errno = false);
   void shutdownSsl();
   bool isThreadSafe() const {
     return callbacks_ != nullptr && callbacks_->connection().dispatcher().isThreadSafe();


### PR DESCRIPTION
backport of https://github.com/Maistra/envoy/pull/27