### PR TITLE
[WIP] MAISTRA-1166: Treat EAGAIN as SSL_ERROR_WANT_READ

### DIFF
--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -131,10 +131,16 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
         case SSL_ERROR_ZERO_RETURN:
           end_stream = true;
           break;
+        case SSL_ERROR_SSL:
+          // If EAGAIN treat it as if it's SSL_ERROR_WANT_READ
+          if (errno == EAGAIN) {
+            break;
+          }
+          // fall through for other errors
         case SSL_ERROR_WANT_WRITE:
         // Renegotiation has started. We don't handle renegotiation so just fall through.
         default:
-          drainErrorQueue();
+          drainErrorQueue(true);
           action = PostIoAction::Close;
           break;
         }


### PR DESCRIPTION
This cherry-picks the fix for Maistra-1166 to Maistra-2.0. Creating the PR so that our GitHub tests can run. Will test against Maistra-1859 to confirm that this fixes that.