### PR TITLE
Fixes MAISTRA-2017: backport to Maistra-1.1: udp: properly handle tru…

### DIFF
--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -97,6 +97,9 @@ public:
     std::shared_ptr<const Address::Instance> local_address_;
     // The the source address from transport header.
     std::shared_ptr<const Address::Instance> peer_address_;
+    // If true indicates a successful syscall, but the packet was dropped due to truncation. We do
+    // not support receiving truncated packets.
+    bool truncated_and_dropped_{false};
   };
 
   /**

--- a/source/common/network/udp_listener_impl.h
+++ b/source/common/network/udp_listener_impl.h
@@ -26,6 +26,7 @@ public:
                   TimeSource& time_source);
 
   ~UdpListenerImpl() override;
+  uint32_t packetsDropped() { return packets_dropped_; }
 
   // Network::Listener Interface
   void disable() override;

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -544,7 +544,7 @@ Api::IoCallUint64Result Utility::readFromSocket(Network::Socket& socket,
   Api::IoCallUint64Result result =
       socket.ioHandle().recvmsg(&slice, num_slices, socket.localAddress()->ip()->port(), output);
 
-  if (!result.ok()) {
+  if (!result.ok() || output.truncated_and_dropped_) {
     return result;
   }
 


### PR DESCRIPTION
…ncated/dropped

datagrams (#14130)

Signed-off-by: Matt Klein <mklein@lyft.com>
Signed-off-by: Christoph Pakulski <christoph@tetrate.io>
Co-authored-by: Matt Klein <mklein@lyft.com>
Co-authored-by: Christoph Pakulski <christoph@tetrate.io>

Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
