### PR TITLE
MAISTRA-2100 SegV in test shutdown.

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1428,16 +1428,15 @@ envoy_cc_fuzz_test(
     deps = [":h2_fuzz_persistent_lib"],
 )
 
-# FIXME: https://issues.redhat.com/browse/MAISTRA-2100
-# envoy_cc_fuzz_test(
-#     name = "h2_capture_direct_response_fuzz_test",
-#     srcs = ["h2_capture_direct_response_fuzz_test.cc"],
-#     corpus = "h2_corpus",
-#     deps = [
-#         ":h2_fuzz_lib",
-#         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
-#     ],
-# )
+envoy_cc_fuzz_test(
+    name = "h2_capture_direct_response_fuzz_test",
+    srcs = ["h2_capture_direct_response_fuzz_test.cc"],
+    corpus = "h2_corpus",
+    deps = [
+        ":h2_fuzz_lib",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+    ],
+)
 
 envoy_cc_fuzz_test(
     name = "h2_capture_direct_response_persistent_fuzz_test",

--- a/test/integration/h2_fuzz.cc
+++ b/test/integration/h2_fuzz.cc
@@ -261,6 +261,7 @@ void H2FuzzIntegrationTest::replay(const test::integration::H2CaptureFuzzTestCas
   }
   if (tcp_client->connected()) {
     tcp_client->close();
+    test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
   }
 }
 


### PR DESCRIPTION
A SegV was occurring in the test shutdown in the RAND_bytes() call
in OpenSSL library.  This was due to the sequencing of calls between
client/server for connection termination.

Commit Message:
Additional Description:
Risk Level: low
Testing: runs no errors.
Docs Changes: none.
Release Notes:
[Optional Runtime guard:]
Optional Fixes #Issue
MAISTRA-2100
[Optional Deprecated:]
