### PR TITLE
Fixes MAISTRA-2200: updated lua-jit

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -67,16 +67,13 @@ configure_make(
         # TODO(htuch): Remove when #6084 is fixed
         "//bazel:asan_build": {"ENVOY_CONFIG_ASAN": "1"},
         "//bazel:msan_build": {"ENVOY_CONFIG_MSAN": "1"},
-        "//bazel:windows_dbg_build": {"WINDOWS_DBG_BUILD": "debug"},
         "//conditions:default": {},
     }),
     lib_source = "@com_github_moonjit_moonjit//:all",
     make_commands = [],
     out_include_dir = "include/moonjit-2.2",
-    static_libraries = select({
-        "//bazel:windows_x86_64": ["lua51.lib"],
-        "//conditions:default": ["libluajit-5.1.a"],
-    }),
+    static_libraries = ["libluajit-5.1.a"],
+    tags = ["skip_on_windows"],
 )
 
 envoy_cmake_external(

--- a/bazel/foreign_cc/luajit.patch
+++ b/bazel/foreign_cc/luajit.patch
@@ -1,5 +1,5 @@
 diff --git a/src/Makefile b/src/Makefile
-index f56465d..5d91fa7 100644
+index e65b55e..f0a61dd 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -27,7 +27,7 @@ NODOTABIVER= 51
@@ -33,38 +33,35 @@ index f56465d..5d91fa7 100644
  #
  # Disable the JIT compiler, i.e. turn LuaJIT into a pure interpreter.
  #XCFLAGS+= -DLUAJIT_DISABLE_JIT
-@@ -111,7 +111,7 @@ XCFLAGS=
- #XCFLAGS+= -DLUAJIT_NUMMODE=2
- #
- # Enable GC64 mode for x64.
--#XCFLAGS+= -DLUAJIT_ENABLE_GC64
-+XCFLAGS+= -DLUAJIT_ENABLE_GC64
- #
- ##############################################################################
-
-@@ -587,7 +587,7 @@ endif
-
+@@ -591,7 +591,7 @@ endif
+ 
  Q= @
  E= @echo
 -#Q=
 +Q=
  #E= @:
-
+ 
  ##############################################################################
-EOF
---- a/src/msvcbuild.bat	2020-08-13 18:42:05.667354300 +0000
-+++ b/src/msvcbuild.bat	2020-08-13 19:03:25.092297900 +0000
-@@ -14,7 +14,7 @@
+diff --git a/src/msvcbuild.bat b/src/msvcbuild.bat
+index ae035dc..0e7eac9 100644
+--- a/src/msvcbuild.bat
++++ b/src/msvcbuild.bat
+@@ -13,9 +13,7 @@
  @if not defined INCLUDE goto :FAIL
  
  @setlocal
+-@rem Add more debug flags here, e.g. DEBUGCFLAGS=/DLUA_USE_APICHECK
+-@set DEBUGCFLAGS=
 -@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline
 +@set LJCOMPILE=cl /nologo /c /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline /DLUAJIT_ENABLE_LUA52COMPAT
  @set LJLINK=link /nologo
  @set LJMT=mt /nologo
  @set LJLIB=lib /nologo /nodefaultlib
-@@ -25,7 +25,7 @@
+@@ -24,10 +22,9 @@
+ @set DASC=vm_x64.dasc
+ @set LJDLLNAME=lua51.dll
  @set LJLIBNAME=lua51.lib
+-@set BUILDTYPE=release
  @set ALL_LIB=lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c
  
 -%LJCOMPILE% host\minilua.c
@@ -72,7 +69,7 @@ EOF
  @if errorlevel 1 goto :BAD
  %LJLINK% /out:minilua.exe minilua.obj
  @if errorlevel 1 goto :BAD
-@@ -48,7 +48,7 @@
+@@ -51,7 +48,7 @@ if exist minilua.exe.manifest^
  minilua %DASM% -LN %DASMFLAGS% -o host\buildvm_arch.h %DASC%
  @if errorlevel 1 goto :BAD
  
@@ -81,16 +78,19 @@ EOF
  @if errorlevel 1 goto :BAD
  %LJLINK% /out:buildvm.exe buildvm*.obj
  @if errorlevel 1 goto :BAD
-@@ -72,24 +72,35 @@
+@@ -75,26 +72,35 @@ buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
  
  @if "%1" neq "debug" goto :NODEBUG
  @shift
--@set LJCOMPILE=%LJCOMPILE% /Zi
+-@set BUILDTYPE=debug
+-@set LJCOMPILE=%LJCOMPILE% /Zi %DEBUGCFLAGS%
+-@set LJLINK=%LJLINK% /opt:ref /opt:icf /incremental:no
 +@set LJCOMPILE=%LJCOMPILE% /O0 /Z7
- @set LJLINK=%LJLINK% /debug /opt:ref /opt:icf /incremental:no
++@set LJLINK=%LJLINK% /debug /opt:ref /opt:icf /incremental:no
 +@set LJCRTDBG=d
 +@goto :ENDDEBUG
  :NODEBUG
+-@set LJLINK=%LJLINK% /%BUILDTYPE%
 +@set LJCOMPILE=%LJCOMPILE% /O2 /Z7
 +@set LJLINK=%LJLINK% /release /incremental:no
 +@set LJCRTDBG=
@@ -122,7 +122,7 @@ EOF
  @if errorlevel 1 goto :BAD
 diff --git a/build.py b/build.py
 new file mode 100755
-index 0000000..9c71271
+index 0000000..3eb74ff
 --- /dev/null
 +++ b/build.py
 @@ -0,0 +1,56 @@
@@ -168,7 +168,7 @@ index 0000000..9c71271
 +    dst_dir = os.getcwd() + "/luajit"
 +    shutil.copytree(src_dir, os.path.basename(src_dir))
 +    os.chdir(os.path.basename(src_dir) + "/src")
-+    os.system('msvcbuild.bat gc64 ' + os.getenv('WINDOWS_DBG_BUILD', '') + ' static')
++    os.system('msvcbuild.bat ' + os.getenv('WINDOWS_DBG_BUILD', '') + ' static')
 +    os.makedirs(dst_dir + "/lib", exist_ok=True)
 +    shutil.copy("lua51.lib", dst_dir + "/lib")
 +    os.makedirs(dst_dir + "/include/luajit-2.1", exist_ok=True)

--- a/bazel/foreign_cc/moonjit.patch
+++ b/bazel/foreign_cc/moonjit.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000..dab3606c
 --- /dev/null
 +++ b/build.py
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,39 @@
 +#!/usr/bin/env python3
 +
 +import argparse
@@ -41,24 +41,7 @@ index 00000000..dab3606c
 +
 +    os.system('make -j{} V=1 PREFIX="{}" install'.format(os.cpu_count(), args.prefix))
 +
-+def win_main():
-+    src_dir = os.path.dirname(os.path.realpath(__file__))
-+    dst_dir = os.getcwd() + "/moonjit"
-+    shutil.copytree(src_dir, os.path.basename(src_dir))
-+    os.chdir(os.path.basename(src_dir) + "/src")
-+    os.system('msvcbuild.bat gc64 ' + os.getenv('WINDOWS_DBG_BUILD', '') + ' static')
-+    os.makedirs(dst_dir + "/lib", exist_ok=True)
-+    shutil.copy("lua51.lib", dst_dir + "/lib")
-+    os.makedirs(dst_dir + "/include/moonjit-2.2", exist_ok=True)
-+    for header in ["lauxlib.h", "luaconf.h", "lua.h", "lua.hpp", "luajit.h", "lualib.h"]:
-+      shutil.copy(header, dst_dir + "/include/moonjit-2.2")
-+    os.makedirs(dst_dir + "/bin", exist_ok=True)
-+    shutil.copy("luajit.exe", dst_dir + "/bin")
-+
-+if os.name == 'nt':
-+  win_main()
-+else:
-+  main()
++main()
 +
 diff --git a/src/Makefile b/src/Makefile
 index dad9aeec..e10b3118 100644
@@ -104,78 +87,3 @@ index dad9aeec..e10b3118 100644
  #E= @:
  
  ##############################################################################
-diff --git a/src/msvcbuild.bat b/src/msvcbuild.bat
-index c2d2c212..71f24422 100644
---- a/src/msvcbuild.bat
-+++ b/src/msvcbuild.bat
-@@ -15,7 +15,7 @@
- @setlocal
- @rem Add more debug flags here, e.g. DEBUGCFLAGS=/DLUA_USE_APICHECK
- @set DEBUGCFLAGS=
--@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline
-+@set LJCOMPILE=cl /nologo /c /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline /DLUAJIT_ENABLE_LUA52COMPAT
- @set LJLINK=link /nologo
- @set LJMT=mt /nologo
- @set LJLIB=lib /nologo /nodefaultlib
-@@ -24,10 +24,9 @@
- @set DASC=vm_x86.dasc
- @set LJDLLNAME=lua51.dll
- @set LJLIBNAME=lua51.lib
--@set BUILDTYPE=release
- @set ALL_LIB=lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c lib_utf8.c
- 
--%LJCOMPILE% host\minilua.c
-+%LJCOMPILE% /O2 host\minilua.c
- @if errorlevel 1 goto :BAD
- %LJLINK% /out:minilua.exe minilua.obj
- @if errorlevel 1 goto :BAD
-@@ -50,7 +49,7 @@ if exist minilua.exe.manifest^
- minilua %DASM% -LN %DASMFLAGS% -o host\buildvm_arch.h %DASC%
- @if errorlevel 1 goto :BAD
- 
--%LJCOMPILE% /I "." /I %DASMDIR% host\buildvm*.c
-+%LJCOMPILE% /O2 /I "." /I %DASMDIR% host\buildvm*.c
- @if errorlevel 1 goto :BAD
- %LJLINK% /out:buildvm.exe buildvm*.obj
- @if errorlevel 1 goto :BAD
-@@ -74,25 +73,35 @@ buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
- 
- @if "%1" neq "debug" goto :NODEBUG
- @shift
--@set BUILDTYPE=debug
--@set LJCOMPILE=%LJCOMPILE% /Zi %DEBUGCFLAGS%
-+@set LJCOMPILE=%LJCOMPILE% /O0 /Z7
-+@set LJLINK=%LJLINK% /debug /opt:ref /opt:icf /incremental:no
-+@set LJCRTDBG=d
-+@goto :ENDDEBUG
- :NODEBUG
--@set LJLINK=%LJLINK% /%BUILDTYPE%
-+@set LJCOMPILE=%LJCOMPILE% /O2 /Z7
-+@set LJLINK=%LJLINK% /release /incremental:no
-+@set LJCRTDBG=
-+:ENDDEBUG
- @if "%1"=="amalg" goto :AMALGDLL
- @if "%1"=="static" goto :STATIC
--%LJCOMPILE% /MD /DLUA_BUILD_AS_DLL lj_*.c lib_*.c
-+@set LJCOMPILE=%LJCOMPILE% /MD%LJCRTDBG%
-+LJCOMPILE% /DLUA_BUILD_AS_DLL lj_*.c lib_*.c
- @if errorlevel 1 goto :BAD
- %LJLINK% /DLL /out:%LJDLLNAME% lj_*.obj lib_*.obj
- @if errorlevel 1 goto :BAD
- @goto :MTDLL
- :STATIC
-+@shift
-+@set LJCOMPILE=%LJCOMPILE% /MT%LJCRTDBG%
- %LJCOMPILE% lj_*.c lib_*.c
- @if errorlevel 1 goto :BAD
- %LJLIB% /OUT:%LJLIBNAME% lj_*.obj lib_*.obj
- @if errorlevel 1 goto :BAD
- @goto :MTDLL
- :AMALGDLL
--%LJCOMPILE% /MD /DLUA_BUILD_AS_DLL ljamalg.c
-+@shift
-+@set LJCOMPILE=%LJCOMPILE% /MD%LJCRTDBG%
-+%LJCOMPILE% /DLUA_BUILD_AS_DLL ljamalg.c
- @if errorlevel 1 goto :BAD
- %LJLINK% /DLL /out:%LJDLLNAME% ljamalg.obj lj_vm.obj
- @if errorlevel 1 goto :BAD

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -292,13 +292,15 @@ DEPENDENCY_REPOSITORIES_SPEC = dict(
         project_name = "LuaJIT",
         project_desc = "Just-In-Time compiler for Lua",
         project_url = "https://luajit.org",
-        version = "2.1.0-beta3",
-        sha256 = "409f7fe570d3c16558e594421c47bdd130238323c9d6fd6c83dedd2aaeb082a8",
+        # The last release version, 2.1.0-beta3 has a number of CVEs filed
+        # against it. These may not impact correct non-malicious Lua code, but for prudence we bump.
+        version = "1d8b747c161db457e032a023ebbff511f5de5ec2",
+        sha256 = "20a159c38a98ecdb6368e8d655343b6036622a29a1621da9dc303f7ed9bf37f3",
         strip_prefix = "LuaJIT-{version}",
-        urls = ["https://github.com/LuaJIT/LuaJIT/archive/v{version}.tar.gz"],
+        urls = ["https://github.com/LuaJIT/LuaJIT/archive/{version}.tar.gz"],
+        last_updated = "2020-10-13",
         use_category = ["dataplane_ext"],
         extensions = ["envoy.filters.http.lua"],
-        last_updated = "2017-11-07",
         cpe = "cpe:2.3:a:luajit:luajit:*",
     ),
     com_github_moonjit_moonjit = dict(

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -809,13 +809,14 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestRequestHeaderMapImpl{{":path", "/"},
-                                                      {":method", "POST"},
-                                                      {":authority", "foo"},
-                                                      {"set-cookie", "flavor=chocolate; Path=/"},
-                                                      {"set-cookie", "variant=chewy; Path=/"},
-                                                      {"content-length", "11"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":method", "POST"},
+                {":path", "/"},
+                {":authority", "foo"},
+                {"set-cookie", "flavor=chocolate; Path=/"},
+                {"set-cookie", "variant=chewy; Path=/"},
+                {"content-length", "11"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -877,13 +878,14 @@ TEST_F(LuaHttpFilterTest, HttpCallAsyncFalse) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestRequestHeaderMapImpl{{":path", "/"},
-                                                      {":method", "POST"},
-                                                      {":authority", "foo"},
-                                                      {"set-cookie", "flavor=chocolate; Path=/"},
-                                                      {"set-cookie", "variant=chewy; Path=/"},
-                                                      {"content-length", "11"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":path", "/"},
+                {":method", "POST"},
+                {":authority", "foo"},
+                {"set-cookie", "flavor=chocolate; Path=/"},
+                {"set-cookie", "variant=chewy; Path=/"},
+                {"content-length", "11"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -936,13 +938,14 @@ TEST_F(LuaHttpFilterTest, HttpCallAsynchronous) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestRequestHeaderMapImpl{{":path", "/"},
-                                                      {":method", "POST"},
-                                                      {":authority", "foo"},
-                                                      {"set-cookie", "flavor=chocolate; Path=/"},
-                                                      {"set-cookie", "variant=chewy; Path=/"},
-                                                      {"content-length", "11"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":path", "/"},
+                {":method", "POST"},
+                {":authority", "foo"},
+                {"set-cookie", "flavor=chocolate; Path=/"},
+                {"set-cookie", "variant=chewy; Path=/"},
+                {"content-length", "11"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -1004,11 +1007,11 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestRequestHeaderMapImpl{{":path", "/"},
-                                                      {":method", "POST"},
-                                                      {":authority", "foo"},
-                                                      {"content-length", "11"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{{":path", "/"},
+                                                                  {":method", "POST"},
+                                                                  {":authority", "foo"},
+                                                                  {"content-length", "11"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -1027,9 +1030,9 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestRequestHeaderMapImpl{
-                          {":path", "/bar"}, {":method", "GET"}, {":authority", "foo"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":path", "/bar"}, {":method", "GET"}, {":authority", "foo"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -1084,9 +1087,9 @@ TEST_F(LuaHttpFilterTest, HttpCallNoBody) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestRequestHeaderMapImpl{
-                          {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":path", "/"}, {":method", "GET"}, {":authority", "foo"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -1142,9 +1145,9 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestRequestHeaderMapImpl{
-                          {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":path", "/"}, {":method", "GET"}, {":authority", "foo"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -293,7 +293,6 @@ TEST_F(LuaStreamInfoWrapperTest, SetGetAndIterateDynamicMetadata) {
       end
     )EOF"};
 
-  InSequence s;
   setup(SCRIPT);
 
   StreamInfo::StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem());

--- a/test/test_common/utility_test.cc
+++ b/test/test_common/utility_test.cc
@@ -28,6 +28,24 @@ TEST(HeaderMapEqualIgnoreOrder, NotEqual) {
   EXPECT_FALSE(TestUtility::headerMapEqualIgnoreOrder(lhs, rhs));
 }
 
+TEST(HeaderMapEqualIgnoreOrder, MultiValue) {
+  {
+    Http::TestRequestHeaderMapImpl lhs{{"bar", "a"}, {"foo", "1"}, {"foo", "2"}};
+    Http::TestRequestHeaderMapImpl rhs{{"foo", "1"}, {"bar", "a"}, {"foo", "2"}};
+    EXPECT_TRUE(TestUtility::headerMapEqualIgnoreOrder(lhs, rhs));
+  }
+  {
+    Http::TestRequestHeaderMapImpl lhs{{"bar", "a"}, {"foo", "1"}, {"foo", "2"}};
+    Http::TestRequestHeaderMapImpl rhs{{"foo", "2"}, {"bar", "a"}, {"foo", "1"}};
+    EXPECT_FALSE(TestUtility::headerMapEqualIgnoreOrder(lhs, rhs));
+  }
+  {
+    Http::TestRequestHeaderMapImpl lhs{{"bar", "a"}, {"foo", "1"}, {"foo", "2"}};
+    Http::TestRequestHeaderMapImpl rhs{{"foo", "1,2"}, {"bar", "a"}};
+    EXPECT_TRUE(TestUtility::headerMapEqualIgnoreOrder(lhs, rhs));
+  }
+}
+
 TEST(ProtoEqIgnoreField, ActuallyEqual) {
   // Ignored field equal
   {


### PR DESCRIPTION
Cherry-pick of ffa2f17902ee7a378a9ff3166bba375751cf465b
    dependencies: bump LuaJIT to 2.1 branch HEAD @ e9af1ab. (#13474)

    LuaJIT 2.1.0-beta3 has the following CVEs, which don't appear
    super critical for correctly functioning Lua code but prudence dictates
    we should bump anyway:

    - CVE-2020-15890: LuaJit through 2.1.0-beta3 has an out-of-bounds read
      because __gc handler frame traversal is mishandled.

    - CVE-2020-24372: LuaJIT through 2.1.0-beta3 has an out-of-bounds read
      in lj_err_run in lj_err.c.

    There is no release version beyond 2.1.0-beta3, so using HEAD of 2.1
    branch.