### PR TITLE
Fixes MAISTRA-2199: update lua-jit for maistra 2.0

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -70,9 +70,7 @@ configure_make(
     lib_source = "@com_github_moonjit_moonjit//:all",
     make_commands = [],
     out_include_dir = "include/moonjit-2.2",
-    static_libraries = [
-        "libluajit-5.1.a",
-    ],
+    static_libraries = ["libluajit-5.1.a"],
     tags = ["skip_on_windows"],
 )
 

--- a/bazel/foreign_cc/luajit.patch
+++ b/bazel/foreign_cc/luajit.patch
@@ -1,5 +1,5 @@
 diff --git a/src/Makefile b/src/Makefile
-index f56465d..3f4f2fa 100644
+index e65b55e..f0a61dd 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -27,7 +27,7 @@ NODOTABIVER= 51
@@ -33,23 +33,100 @@ index f56465d..3f4f2fa 100644
  #
  # Disable the JIT compiler, i.e. turn LuaJIT into a pure interpreter.
  #XCFLAGS+= -DLUAJIT_DISABLE_JIT
-@@ -587,7 +587,7 @@ endif
-
+@@ -591,7 +591,7 @@ endif
+ 
  Q= @
  E= @echo
 -#Q=
 +Q=
  #E= @:
-
+ 
  ##############################################################################
-EOF
+diff --git a/src/msvcbuild.bat b/src/msvcbuild.bat
+index ae035dc..0e7eac9 100644
+--- a/src/msvcbuild.bat
++++ b/src/msvcbuild.bat
+@@ -13,9 +13,7 @@
+ @if not defined INCLUDE goto :FAIL
+ 
+ @setlocal
+-@rem Add more debug flags here, e.g. DEBUGCFLAGS=/DLUA_USE_APICHECK
+-@set DEBUGCFLAGS=
+-@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline
++@set LJCOMPILE=cl /nologo /c /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline /DLUAJIT_ENABLE_LUA52COMPAT
+ @set LJLINK=link /nologo
+ @set LJMT=mt /nologo
+ @set LJLIB=lib /nologo /nodefaultlib
+@@ -24,10 +22,9 @@
+ @set DASC=vm_x64.dasc
+ @set LJDLLNAME=lua51.dll
+ @set LJLIBNAME=lua51.lib
+-@set BUILDTYPE=release
+ @set ALL_LIB=lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c
+ 
+-%LJCOMPILE% host\minilua.c
++%LJCOMPILE% /O2 host\minilua.c
+ @if errorlevel 1 goto :BAD
+ %LJLINK% /out:minilua.exe minilua.obj
+ @if errorlevel 1 goto :BAD
+@@ -51,7 +48,7 @@ if exist minilua.exe.manifest^
+ minilua %DASM% -LN %DASMFLAGS% -o host\buildvm_arch.h %DASC%
+ @if errorlevel 1 goto :BAD
+ 
+-%LJCOMPILE% /I "." /I %DASMDIR% host\buildvm*.c
++%LJCOMPILE% /O2 /I "." /I %DASMDIR% host\buildvm*.c
+ @if errorlevel 1 goto :BAD
+ %LJLINK% /out:buildvm.exe buildvm*.obj
+ @if errorlevel 1 goto :BAD
+@@ -75,26 +72,35 @@ buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
+ 
+ @if "%1" neq "debug" goto :NODEBUG
+ @shift
+-@set BUILDTYPE=debug
+-@set LJCOMPILE=%LJCOMPILE% /Zi %DEBUGCFLAGS%
+-@set LJLINK=%LJLINK% /opt:ref /opt:icf /incremental:no
++@set LJCOMPILE=%LJCOMPILE% /O0 /Z7
++@set LJLINK=%LJLINK% /debug /opt:ref /opt:icf /incremental:no
++@set LJCRTDBG=d
++@goto :ENDDEBUG
+ :NODEBUG
+-@set LJLINK=%LJLINK% /%BUILDTYPE%
++@set LJCOMPILE=%LJCOMPILE% /O2 /Z7
++@set LJLINK=%LJLINK% /release /incremental:no
++@set LJCRTDBG=
++:ENDDEBUG
+ @if "%1"=="amalg" goto :AMALGDLL
+ @if "%1"=="static" goto :STATIC
+-%LJCOMPILE% /MD /DLUA_BUILD_AS_DLL lj_*.c lib_*.c
++@set LJCOMPILE=%LJCOMPILE% /MD%LJCRTDBG% 
++%LJCOMPILE% /DLUA_BUILD_AS_DLL lj_*.c lib_*.c
+ @if errorlevel 1 goto :BAD
+ %LJLINK% /DLL /out:%LJDLLNAME% lj_*.obj lib_*.obj
+ @if errorlevel 1 goto :BAD
+ @goto :MTDLL
+ :STATIC
++@shift
++@set LJCOMPILE=%LJCOMPILE% /MT%LJCRTDBG%
+ %LJCOMPILE% lj_*.c lib_*.c
+ @if errorlevel 1 goto :BAD
+ %LJLIB% /OUT:%LJLIBNAME% lj_*.obj lib_*.obj
+ @if errorlevel 1 goto :BAD
+ @goto :MTDLL
+ :AMALGDLL
+-%LJCOMPILE% /MD /DLUA_BUILD_AS_DLL ljamalg.c
++@shift
++@set LJCOMPILE=%LJCOMPILE% /MD%LJCRTDBG% 
++%LJCOMPILE% /DLUA_BUILD_AS_DLL ljamalg.c
+ @if errorlevel 1 goto :BAD
+ %LJLINK% /DLL /out:%LJDLLNAME% ljamalg.obj lj_vm.obj
+ @if errorlevel 1 goto :BAD
 diff --git a/build.py b/build.py
 new file mode 100755
-index 0000000..9c71271
+index 0000000..3eb74ff
 --- /dev/null
 +++ b/build.py
-@@ -0,0 +1,39 @@
-+#!/usr/bin/env python
+@@ -0,0 +1,56 @@
++#!/usr/bin/env python3
 +
 +import argparse
 +import os
@@ -77,14 +154,31 @@ index 0000000..9c71271
 +      os.environ["HOST_CFLAGS"] = "-fno-sanitize=memory"
 +      os.environ["HOST_LDFLAGS"] = "-fno-sanitize=memory"
 +
-+    # Blacklist LuaJIT from ASAN for now.
++    # Remove LuaJIT from ASAN for now.
 +    # TODO(htuch): Remove this when https://github.com/envoyproxy/envoy/issues/6084 is resolved.
-+    if "ENVOY_CONFIG_ASAN" in os.environ:
-+      os.environ["TARGET_CFLAGS"] += " -fsanitize-blacklist=%s/com_github_luajit_luajit/clang-asan-blacklist.txt" % os.environ["PWD"]
-+      with open("clang-asan-blacklist.txt", "w") as f:
++    if "ENVOY_CONFIG_ASAN" in os.environ or "ENVOY_CONFIG_MSAN" in os.environ:
++      os.environ["TARGET_CFLAGS"] += " -fsanitize-blacklist=%s/com_github_luajit_luajit/clang-asan-blocklist.txt" % os.environ["PWD"]
++      with open("clang-asan-blocklist.txt", "w") as f:
 +        f.write("fun:*\n")
 +
-+    os.system('make V=1 PREFIX="{}" install'.format(args.prefix))
++    os.system('make -j{} V=1 PREFIX="{}" install'.format(os.cpu_count(), args.prefix))
 +
-+main()
++def win_main():
++    src_dir = os.path.dirname(os.path.realpath(__file__))
++    dst_dir = os.getcwd() + "/luajit"
++    shutil.copytree(src_dir, os.path.basename(src_dir))
++    os.chdir(os.path.basename(src_dir) + "/src")
++    os.system('msvcbuild.bat ' + os.getenv('WINDOWS_DBG_BUILD', '') + ' static')
++    os.makedirs(dst_dir + "/lib", exist_ok=True)
++    shutil.copy("lua51.lib", dst_dir + "/lib")
++    os.makedirs(dst_dir + "/include/luajit-2.1", exist_ok=True)
++    for header in ["lauxlib.h", "luaconf.h", "lua.h", "lua.hpp", "luajit.h", "lualib.h"]:
++      shutil.copy(header, dst_dir + "/include/luajit-2.1")
++    os.makedirs(dst_dir + "/bin", exist_ok=True)
++    shutil.copy("luajit.exe", dst_dir + "/bin")
++
++if os.name == 'nt':
++  win_main()
++else:
++  main()
 +

--- a/bazel/foreign_cc/moonjit.patch
+++ b/bazel/foreign_cc/moonjit.patch
@@ -1,5 +1,50 @@
+diff --git a/build.py b/build.py
+new file mode 100644
+index 00000000..dab3606c
+--- /dev/null
++++ b/build.py
+@@ -0,0 +1,39 @@
++#!/usr/bin/env python3
++
++import argparse
++import os
++import shutil
++
++def main():
++    parser = argparse.ArgumentParser()
++    parser.add_argument("--prefix")
++    args = parser.parse_args()
++    src_dir = os.path.dirname(os.path.realpath(__file__))
++    shutil.copytree(src_dir, os.path.basename(src_dir))
++    os.chdir(os.path.basename(src_dir))
++
++    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.6"
++    os.environ["DEFAULT_CC"] = os.environ.get("CC", "")
++    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
++    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
++    os.environ["CFLAGS"] = ""
++    # LuaJIT compile process build a tool `buildvm` and use it, building `buildvm` with ASAN
++    # will cause LSAN detect its leak and fail the build, set exitcode to 0 to make LSAN doesn't
++    # fail on it.
++    os.environ["LSAN_OPTIONS"] = "exitcode=0"
++
++    if "ENVOY_MSAN" in os.environ:
++      os.environ["HOST_CFLAGS"] = "-fno-sanitize=memory"
++      os.environ["HOST_LDFLAGS"] = "-fno-sanitize=memory"
++
++    # Remove LuaJIT from ASAN for now.
++    # TODO(htuch): Remove this when https://github.com/envoyproxy/envoy/issues/6084 is resolved.
++    if "ENVOY_CONFIG_ASAN" in os.environ or "ENVOY_CONFIG_MSAN" in os.environ:
++      os.environ["TARGET_CFLAGS"] += " -fsanitize-blacklist=%s/com_github_moonjit_moonjit/clang-asan-blocklist.txt" % os.environ["PWD"]
++      with open("clang-asan-blocklist.txt", "w") as f:
++        f.write("fun:*\n")
++
++    os.system('make -j{} V=1 PREFIX="{}" install'.format(os.cpu_count(), args.prefix))
++
++main()
++
 diff --git a/src/Makefile b/src/Makefile
-index f56465d..3f4f2fa 100644
+index dad9aeec..e10b3118 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -27,7 +27,7 @@ NODOTABIVER= 51
@@ -33,58 +78,12 @@ index f56465d..3f4f2fa 100644
  #
  # Disable the JIT compiler, i.e. turn LuaJIT into a pure interpreter.
  #XCFLAGS+= -DLUAJIT_DISABLE_JIT
-@@ -587,7 +587,7 @@ endif
-
+@@ -612,7 +612,7 @@ endif
+ 
  Q= @
  E= @echo
 -#Q=
 +Q=
  #E= @:
-
+ 
  ##############################################################################
-EOF
-diff --git a/build.py b/build.py
-new file mode 100755
-index 0000000..9c71271
---- /dev/null
-+++ b/build.py
-@@ -0,0 +1,39 @@
-+#!/usr/bin/env python
-+
-+import argparse
-+import os
-+import shutil
-+
-+def main():
-+    parser = argparse.ArgumentParser()
-+    parser.add_argument("--prefix")
-+    args = parser.parse_args()
-+    src_dir = os.path.dirname(os.path.realpath(__file__))
-+    shutil.copytree(src_dir, os.path.basename(src_dir))
-+    os.chdir(os.path.basename(src_dir))
-+
-+    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.6"
-+    os.environ["DEFAULT_CC"] = os.environ.get("CC", "")
-+    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
-+    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
-+    os.environ["CFLAGS"] = ""
-+    # LuaJIT compile process build a tool `buildvm` and use it, building `buildvm` with ASAN
-+    # will cause LSAN detect its leak and fail the build, set exitcode to 0 to make LSAN doesn't
-+    # fail on it.
-+    os.environ["LSAN_OPTIONS"] = "exitcode=0"
-+
-+    if "ENVOY_MSAN" in os.environ:
-+      os.environ["HOST_CFLAGS"] = "-fno-sanitize=memory"
-+      os.environ["HOST_LDFLAGS"] = "-fno-sanitize=memory"
-+
-+    # Blacklist LuaJIT from ASAN for now.
-+    # TODO(htuch): Remove this when https://github.com/envoyproxy/envoy/issues/6084 is resolved.
-+    if "ENVOY_CONFIG_ASAN" in os.environ:
-+      os.environ["TARGET_CFLAGS"] += " -fsanitize-blacklist=%s/com_github_moonjit_moonjit/clang-asan-blacklist.txt" % os.environ["PWD"]
-+      with open("clang-asan-blacklist.txt", "w") as f:
-+        f.write("fun:*\n")
-+
-+    os.system('make V=1 PREFIX="{}" install'.format(args.prefix))
-+
-+main()
-+

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -117,9 +117,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/grpc/grpc/archive/d8f4928fa779f6005a7fe55a176bdb373b0f910f.tar.gz"],
     ),
     com_github_luajit_luajit = dict(
-        sha256 = "409f7fe570d3c16558e594421c47bdd130238323c9d6fd6c83dedd2aaeb082a8",
-        strip_prefix = "LuaJIT-2.1.0-beta3",
-        urls = ["https://github.com/LuaJIT/LuaJIT/archive/v2.1.0-beta3.tar.gz"],
+        sha256 = "20a159c38a98ecdb6368e8d655343b6036622a29a1621da9dc303f7ed9bf37f3",
+        strip_prefix = "LuaJIT-1d8b747c161db457e032a023ebbff511f5de5ec2",
+        urls = ["https://github.com/LuaJIT/LuaJIT/archive/1d8b747c161db457e032a023ebbff511f5de5ec2.tar.gz"],
     ),
     com_github_moonjit_moonjit = dict(
         sha256 = "83deb2c880488dfe7dd8ebf09e3b1e7613ef4b8420de53de6f712f01aabca2b6",

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -771,13 +771,14 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
-                                               {":method", "POST"},
-                                               {":authority", "foo"},
-                                               {"set-cookie", "flavor=chocolate; Path=/"},
-                                               {"set-cookie", "variant=chewy; Path=/"},
-                                               {"content-length", "11"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":method", "POST"},
+                {":path", "/"},
+                {":authority", "foo"},
+                {"set-cookie", "flavor=chocolate; Path=/"},
+                {"set-cookie", "variant=chewy; Path=/"},
+                {"content-length", "11"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -834,13 +835,14 @@ TEST_F(LuaHttpFilterTest, HttpCallAsyncFalse) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
-                                               {":method", "POST"},
-                                               {":authority", "foo"},
-                                               {"set-cookie", "flavor=chocolate; Path=/"},
-                                               {"set-cookie", "variant=chewy; Path=/"},
-                                               {"content-length", "11"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":path", "/"},
+                {":method", "POST"},
+                {":authority", "foo"},
+                {"set-cookie", "flavor=chocolate; Path=/"},
+                {"set-cookie", "variant=chewy; Path=/"},
+                {"content-length", "11"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -893,13 +895,14 @@ TEST_F(LuaHttpFilterTest, HttpCallAsynchronous) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
-                                               {":method", "POST"},
-                                               {":authority", "foo"},
-                                               {"set-cookie", "flavor=chocolate; Path=/"},
-                                               {"set-cookie", "variant=chewy; Path=/"},
-                                               {"content-length", "11"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":path", "/"},
+                {":method", "POST"},
+                {":authority", "foo"},
+                {"set-cookie", "flavor=chocolate; Path=/"},
+                {"set-cookie", "variant=chewy; Path=/"},
+                {"content-length", "11"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -961,11 +964,11 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
-                                               {":method", "POST"},
-                                               {":authority", "foo"},
-                                               {"content-length", "11"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{{":path", "/"},
+                                                                  {":method", "POST"},
+                                                                  {":authority", "foo"},
+                                                                  {"content-length", "11"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -984,9 +987,9 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{
-                          {":path", "/bar"}, {":method", "GET"}, {":authority", "foo"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":path", "/bar"}, {":method", "GET"}, {":authority", "foo"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -1040,9 +1043,9 @@ TEST_F(LuaHttpFilterTest, HttpCallNoBody) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{
-                          {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":path", "/"}, {":method", "GET"}, {":authority", "foo"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));
@@ -1098,9 +1101,9 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{
-                          {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
-                      message->headers());
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":path", "/"}, {":method", "GET"}, {":authority", "foo"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
             callbacks = &cb;
             return &request;
           }));

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -293,7 +293,6 @@ TEST_F(LuaStreamInfoWrapperTest, SetGetAndIterateDynamicMetadata) {
       end
     )EOF"};
 
-  InSequence s;
   setup(SCRIPT);
 
   StreamInfo::StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem());

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -110,6 +110,7 @@ envoy_cc_test_library(
         "//source/common/filesystem:directory_lib",
         "//source/common/filesystem:filesystem_lib",
         "//source/common/http:header_map_lib",
+	"//source/common/http:header_utility_lib",
         "//source/common/json:json_loader_lib",
         "//source/common/network:address_lib",
         "//source/common/network:utility_lib",

--- a/test/test_common/utility_test.cc
+++ b/test/test_common/utility_test.cc
@@ -27,6 +27,24 @@ TEST(HeaderMapEqualIgnoreOrder, NotEqual) {
   EXPECT_FALSE(TestUtility::headerMapEqualIgnoreOrder(lhs, rhs));
 }
 
+TEST(HeaderMapEqualIgnoreOrder, MultiValue) {
+  {
+    Http::TestRequestHeaderMapImpl lhs{{"bar", "a"}, {"foo", "1"}, {"foo", "2"}};
+    Http::TestRequestHeaderMapImpl rhs{{"foo", "1"}, {"bar", "a"}, {"foo", "2"}};
+    EXPECT_TRUE(TestUtility::headerMapEqualIgnoreOrder(lhs, rhs));
+  }
+  {
+    Http::TestRequestHeaderMapImpl lhs{{"bar", "a"}, {"foo", "1"}, {"foo", "2"}};
+    Http::TestRequestHeaderMapImpl rhs{{"foo", "2"}, {"bar", "a"}, {"foo", "1"}};
+    EXPECT_FALSE(TestUtility::headerMapEqualIgnoreOrder(lhs, rhs));
+  }
+  {
+    Http::TestRequestHeaderMapImpl lhs{{"bar", "a"}, {"foo", "1"}, {"foo", "2"}};
+    Http::TestRequestHeaderMapImpl rhs{{"foo", "1,2"}, {"bar", "a"}};
+    EXPECT_TRUE(TestUtility::headerMapEqualIgnoreOrder(lhs, rhs));
+  }
+}
+
 TEST(ProtoEqIgnoreField, ActuallyEqual) {
   // Ignored field equal
   {


### PR DESCRIPTION
cherry-pick/port of ffa2f17902ee7a378a9ff3166bba375751cf465b

dependencies: bump LuaJIT to 2.1 branch HEAD @ e9af1ab. (#13474)

LuaJIT 2.1.0-beta3 has the following CVEs, which don't appear
super critical for correctly functioning Lua code but prudence dictates
we should bump anyway:

- CVE-2020-15890: LuaJit through 2.1.0-beta3 has an out-of-bounds read
  because __gc handler frame traversal is mishandled.

- CVE-2020-24372: LuaJIT through 2.1.0-beta3 has an out-of-bounds read
  in lj_err_run in lj_err.c.

There is no release version beyond 2.1.0-beta3, so using HEAD of 2.1
branch.

Risk level: Medium (if using LuaJIT).
Testing: bazel test //test/... Some unit tests required fixups due to
  changes in Lua header map table ordering.

Signed-off-by: Harvey Tuch <htuch@google.com>
Co-authored-by: Michael Payne <michael@sooper.org>
Co-authored-by: William A Rowe Jr <wrowe@vmware.com>
