### PR TITLE
Fixes MAISTRA-2118:  BIO_new_io_handle is functional under OpenSSL now

### DIFF
--- a/source/extensions/transport_sockets/tls/BUILD
+++ b/source/extensions/transport_sockets/tls/BUILD
@@ -52,16 +52,16 @@ envoy_cc_library(
     ],
 )
 
-#envoy_cc_library(
-#    name = "io_handle_bio_lib",
-#    srcs = ["io_handle_bio.cc"],
-#    hdrs = ["io_handle_bio.h"],
-#    external_deps = ["ssl"],
-#    deps = [
-#        "//include/envoy/buffer:buffer_interface",
-#        "//include/envoy/network:io_handle_interface",
-#    ],
-#)
+envoy_cc_library(
+    name = "io_handle_bio_lib",
+    srcs = ["io_handle_bio.cc"],
+    hdrs = ["io_handle_bio.h"],
+    external_deps = ["ssl"],
+    deps = [
+        "//include/envoy/buffer:buffer_interface",
+        "//include/envoy/network:io_handle_interface",
+    ],
+)
 
 envoy_cc_library(
     name = "ssl_socket_lib",
@@ -80,7 +80,7 @@ envoy_cc_library(
     deps = [
         ":context_config_lib",
         ":context_lib",
-#        ":io_handle_bio_lib",
+        ":io_handle_bio_lib",
         ":ssl_handshaker_lib",
         ":utility_lib",
         "//include/envoy/network:connection_interface",

--- a/source/extensions/transport_sockets/tls/io_handle_bio.cc
+++ b/source/extensions/transport_sockets/tls/io_handle_bio.cc
@@ -5,6 +5,7 @@
 
 #include "openssl/bio.h"
 #include "openssl/err.h"
+#include <iostream>
 
 namespace Envoy {
 namespace Extensions {
@@ -15,15 +16,15 @@ namespace {
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 inline Envoy::Network::IoHandle* bio_io_handle(BIO* bio) {
-  return reinterpret_cast<Envoy::Network::IoHandle*>(bio->ptr);
+  return reinterpret_cast<Envoy::Network::IoHandle*>(BIO_get_data(bio));
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 int io_handle_new(BIO* bio) {
-  bio->init = 0;
-  bio->num = -1;
-  bio->ptr = nullptr;
-  bio->flags = 0;
+  BIO_set_init(bio, 0);
+  BIO_set_data(bio, nullptr);
+  BIO_clear_flags(bio, INT_MAX); // clear all bits in a 64bit int
+
   return 1;
 }
 
@@ -33,12 +34,16 @@ int io_handle_free(BIO* bio) {
     return 0;
   }
 
-  if (bio->shutdown) {
-    if (bio->init) {
+  if (BIO_get_shutdown(bio) == 1) {
+    if (BIO_get_init(bio) == 1) {
       bio_io_handle(bio)->close();
     }
-    bio->init = 0;
-    bio->flags = 0;
+    BIO_set_init(bio, 0);
+    BIO_clear_flags(bio, INT_MAX);
+    auto* meth = static_cast<BIO_METHOD*>(BIO_get_app_data(bio));
+    if (meth != nullptr) {
+      BIO_meth_free(meth);
+    }
   }
   return 1;
 }
@@ -93,10 +98,10 @@ long io_handle_ctrl(BIO* b, int cmd, long num, void*) {
     RELEASE_ASSERT(false, "should not be called");
     break;
   case BIO_CTRL_GET_CLOSE:
-    ret = b->shutdown;
+    ret = BIO_get_shutdown(b);
     break;
   case BIO_CTRL_SET_CLOSE:
-    b->shutdown = int(num);
+    BIO_set_shutdown(b, int(num));
     break;
   case BIO_CTRL_FLUSH:
     ret = 1;
@@ -107,32 +112,28 @@ long io_handle_ctrl(BIO* b, int cmd, long num, void*) {
   }
   return ret;
 }
-
-const BIO_METHOD methods_io_handlep = {
-    BIO_TYPE_SOCKET,    "io_handle",
-    io_handle_write,    io_handle_read,
-    nullptr /* puts */, nullptr /* gets, */,
-    io_handle_ctrl,     io_handle_new,
-    io_handle_free,     nullptr /* callback_ctrl */,
-};
-
-// NOLINTNEXTLINE(readability-identifier-naming)
-const BIO_METHOD* BIO_s_io_handle(void) { return &methods_io_handlep; }
-
 } // namespace
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 BIO* BIO_new_io_handle(Envoy::Network::IoHandle* io_handle) {
   BIO* b;
+  BIO_METHOD* meth = BIO_meth_new(BIO_get_new_index(), "io_handle");
 
-  b = BIO_new(BIO_s_io_handle());
+  // no return value checks on set calls as they always return "1"
+  BIO_meth_set_write(meth, io_handle_write);
+  BIO_meth_set_read(meth, io_handle_read);
+  BIO_meth_set_ctrl(meth, io_handle_ctrl);
+  BIO_meth_set_create(meth, io_handle_new);
+  BIO_meth_set_destroy(meth, io_handle_free);
+
+  b = BIO_new(meth);  
   RELEASE_ASSERT(b != nullptr, "");
 
   // Initialize the BIO
-  b->num = -1;
-  b->ptr = io_handle;
-  b->shutdown = 0;
-  b->init = 1;
+  BIO_set_app_data(b, meth);
+  BIO_set_data(b, io_handle);
+  BIO_set_shutdown(b, 0);
+  BIO_set_init(b, 1);
 
   return b;
 }

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -8,8 +8,7 @@
 #include "common/http/headers.h"
 #include "common/runtime/runtime_features.h"
 
-// TODO (dmitri-d) re-enable when BIO io_handle method has been ported to OpenSSL
-//#include "extensions/transport_sockets/tls/io_handle_bio.h"
+#include "extensions/transport_sockets/tls/io_handle_bio.h"
 #include "extensions/transport_sockets/tls/ssl_handshaker.h"
 #include "extensions/transport_sockets/tls/utility.h"
 
@@ -73,14 +72,13 @@ void SslSocket::setTransportSocketCallbacks(Network::TransportSocketCallbacks& c
   }
 
   BIO* bio;
-  // TODO (dmitri-d) re-enable BIO_new_io_handle once ported to OpenSSL
-  //if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.tls_use_io_handle_bio")) {
+  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.tls_use_io_handle_bio")) {
     // Use custom BIO that reads from/writes to IoHandle
-  //  bio = BIO_new_io_handle(&callbacks_->ioHandle());
-  //} else {
+    bio = BIO_new_io_handle(&callbacks_->ioHandle());
+  } else {
     // TODO(fcoras): remove once the io_handle_bio proves to be stable
     bio = BIO_new_socket(callbacks_->ioHandle().fdDoNotUse(), 0);
-  //}
+  }
   SSL_set_bio(rawSsl(), bio, bio);
 }
 

--- a/test/extensions/transport_sockets/tls/BUILD
+++ b/test/extensions/transport_sockets/tls/BUILD
@@ -100,16 +100,16 @@ envoy_cc_test(
     ],
 )
 
-#envoy_cc_test(
-#    name = "io_handle_bio_test",
-#    srcs = ["io_handle_bio_test.cc"],
-#    external_deps = ["ssl"],
-#    deps = [
-#        ":ssl_test_utils",
-#        "//source/extensions/transport_sockets/tls:ssl_socket_lib",
-#        "//test/mocks/network:io_handle_mocks",
-#    ],
-#)
+envoy_cc_test(
+    name = "io_handle_bio_test",
+    srcs = ["io_handle_bio_test.cc"],
+    external_deps = ["ssl"],
+    deps = [
+        ":ssl_test_utils",
+        "//source/extensions/transport_sockets/tls:ssl_socket_lib",
+        "//test/mocks/network:io_handle_mocks",
+    ],
+)
 
 envoy_cc_test(
     name = "utility_test",

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -4717,7 +4717,6 @@ TEST_P(SslSocketTest, UpstreamNotReadySslSocket) {
 TEST_P(SslSocketTest, TestTransportSocketCallback) {
   // Make MockTransportSocketCallbacks.
   Network::MockIoHandle io_handle;
-  EXPECT_CALL(io_handle, fdDoNotUse()).Times(1);
   NiceMock<Network::MockTransportSocketCallbacks> callbacks;
   ON_CALL(callbacks, ioHandle()).WillByDefault(ReturnRef(io_handle));
 


### PR DESCRIPTION
This enables io_handle_bio. 
This required replacing access to what is private data-structures in OpenSSL to use BIO and BIO_METHOD api.  

@oschaaf 