### PR TITLE
Fix a compilation error in ssl_socket_test.cc.

### DIFF
--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -463,7 +463,8 @@ void testUtil(const TestUtilOptions& options) {
         const uint8_t* response_head;
         long response_len = SSL_get_tlsext_status_ocsp_resp(client_ssl_socket, &response_head);
         EXPECT_TRUE(response_len > 0);
-        std::string ocsp_response{reinterpret_cast<const char*>(response_head), response_len};
+        std::string ocsp_response{reinterpret_cast<const char*>(response_head),
+                                  static_cast<unsigned long>(response_len)};
         EXPECT_EQ(options.expectedOcspResponse(), ocsp_response);
       }
 


### PR DESCRIPTION
Fix a compilation error in tests.

    test/extensions/transport_sockets/tls/ssl_socket_test.cc:466:81: error: non-constant-expression cannot be narrowed from type 'long' to 'std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::size_type' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]
            std::string ocsp_response{reinterpret_cast<const char*>(response_head), response_len};

