### PR TITLE
[OSSM-553] Enable lua extension on ppc64le

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -5,7 +5,8 @@ load("@envoy_api//bazel:external_deps.bzl", "load_repository_locations")
 load(":repository_locations.bzl", "REPOSITORY_LOCATIONS_SPEC")
 load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
 
-PPC_SKIP_TARGETS = ["envoy.filters.http.lua"]
+# maistra/envoy uses luajit2 on ppc64le so http.lua can be built
+PPC_SKIP_TARGETS = []
 
 WINDOWS_SKIP_TARGETS = [
     "envoy.tracers.dynamic_ot",


### PR DESCRIPTION
Commit Message: Enable lua extension on ppc64le
Additional Description: Now that luajit2 is imported and enabled automatically on ppc, this is needed to actually build the http.lua extension.
Risk Level: Medium
Testing: Built on ppc64le (downstream)
Docs Changes: ??
Release Notes: ??
Platform Specific Features: Affects ppc64le only.

/cc @jwendell
