### PR TITLE
Adding .gitleaks for identifying test data secrets

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,9 @@
 title = "Maistra Envoy gitleaks configuration"
 
+# The following rule lists all affected files and folders
+# to account for all known files so any additions can be flagged.
+# To be complete each file should have a regexp to identify
+# the specific key in question (todo). 
 [[rules]]
    description = "PRIVATE KEY CHECK PATHS"
    regex = '''-----BEGIN ((EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY( BLOCK)?-----'''
@@ -11,9 +15,6 @@ title = "Maistra Envoy gitleaks configuration"
          '''^test/common/quic/envoy_quic_proof_source_test.cc$''',
          '''^test/extensions/filters/http/jwt_authn/test_common.h$''',
          '''^contrib/cryptomb/private_key_providers/test/config_test.cc$''',
-         '''^contrib/sxg/filters/http/test/filter_test.cc$''',
-         '''^contrib/sxg/filters/http/test/filter_test.cc$''',
-         '''^contrib/sxg/filters/http/test/filter_test.cc$''',
          '''^contrib/sxg/filters/http/test/filter_test.cc$''',
          '''^test/extensions/transport_sockets/tls/test_data/(.*?).(pem|key)$''',
          '''^test/extensions/transport_sockets/tls/ocsp/test_data/(.*?).(pem|key)$''',

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,25 @@
+title = "Maistra Envoy gitleaks configuration"
+
+[[rules]]
+   description = "PRIVATE KEY CHECK PATHS"
+   regex = '''-----BEGIN ((EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY( BLOCK)?-----'''
+   tags = ["key"]
+   [rules.allowlist]
+      description = "test files"
+      paths = [
+         '''^test/common/grpc/service_key.json$''',
+         '''^test/common/quic/envoy_quic_proof_source_test.cc$''',
+         '''^test/extensions/filters/http/jwt_authn/test_common.h$''',
+         '''^contrib/cryptomb/private_key_providers/test/config_test.cc$''',
+         '''^contrib/sxg/filters/http/test/filter_test.cc$''',
+         '''^contrib/sxg/filters/http/test/filter_test.cc$''',
+         '''^contrib/sxg/filters/http/test/filter_test.cc$''',
+         '''^contrib/sxg/filters/http/test/filter_test.cc$''',
+         '''^test/extensions/transport_sockets/tls/test_data/(.*?).(pem|key)$''',
+         '''^test/extensions/transport_sockets/tls/ocsp/test_data/(.*?).(pem|key)$''',
+         '''^test/config/integration/certs/(.*?).(pem|key)$''',
+         '''^contrib/cryptomb/private_key_providers/test/test_data/(.*?).(pem|key)$''',
+         '''^examples/_extra_certs/(.*?).(pem|key)$''',
+         '''^examples/(.*?)(yaml)$''',
+      ]
+


### PR DESCRIPTION
Signed-off-by: Tim Walsh <temporal.differential@gmail.com>

Red Hat Info Sec identified several embedded secrets in the test data.

This change identifies the files in .gitleaks.toml

Confirmation (test):
```
cd ~/envoy-source-dir
 docker run --rm -v ${PWD}:/my-repo zricethezav/gitleaks:latest --verbose --path="/my-repo"  --repo-config-path=.gitleaks.toml
```
The file paths are fully qualified deliberately as using wild cards (regexps) will potentially allow for missing secret files placed in the directory hierarchy.