### PR TITLE
Ensure librdkafka configured correctly if compiler warnings are disabled

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -44,7 +44,7 @@ cc_library(
 configure_make(
     name = "librdkafka_build",
     configure_in_place = True,
-    configure_options = ["--disable-ssl --disable-gssapi --disable-lz4-ext --disable-zstd && cp Makefile.config src/.. && cp config.h src/.."],
+    configure_options = ["--CFLAGS=\"${CFLAGS:-} -Werror=implicit-function-declaration\" --disable-ssl --disable-gssapi --disable-lz4-ext --disable-zstd && cp Makefile.config src/.. && cp config.h src/.."],
     lib_source = "@edenhill_librdkafka//:all",
     out_static_libs = [
         "librdkafka.a",


### PR DESCRIPTION
When building envoy in the context of maistra/proxy, many compiler warnings are disabled, which causes librdkafka's configure step to incorrectly assume that strlcpy() exists, when in fact it doesn't. This causes librdkafka to get built with undefined references to strlcpy() which then causes the envoy binary link step to fail.

This change ensures that librdkafka gets configured correctly regardless of what compiler warnings are in effect at the higher level

Signed-off-by: Ted Poole <tpoole@redhat.com>
