### PR TITLE
Fixed ownership of SSL_set_tlsext_status_ocsp_resp() parameter

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -990,8 +990,8 @@ int ServerContextImpl::handleOcspStapling(SSL* ssl, void*) {
     RELEASE_ASSERT(cert_context.ocsp_response_,
                    "OCSP response must be present under OcspStapleAction::Staple");
     auto& resp_bytes = cert_context.ocsp_response_->rawBytes();
-    int rc = SSL_set_tlsext_status_ocsp_resp(ssl, const_cast<unsigned char*>(resp_bytes.data()),
-                                             resp_bytes.size());
+    size_t resp_len = resp_bytes.size();
+    int rc = SSL_set_tlsext_status_ocsp_resp(ssl, OPENSSL_memdup (resp_bytes.data(), resp_len), resp_len);
     RELEASE_ASSERT(rc != 0, "Error setting ocsp response");
     stats_.ocsp_staple_responses_.inc();
   }

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -522,7 +522,7 @@ TEST_P(SslCertficateIntegrationTest, BothEcdsaAndRsaOnlyRsaOcspResponse) {
 }
 
 // Server has two certificates, but only ECDSA has OCSP, which should be returned.
-TEST_P(SslCertficateIntegrationTest, DISABLED_BothEcdsaAndRsaOnlyEcdsaOcspResponse) {
+TEST_P(SslCertficateIntegrationTest, BothEcdsaAndRsaOnlyEcdsaOcspResponse) {
   server_rsa_cert_ = true;
   server_ecdsa_cert_ = true;
   server_ecdsa_cert_ocsp_staple_ = true;
@@ -764,7 +764,7 @@ TEST_P(SslTapIntegrationTest, TruncationWithMultipleDataFrames) {
 }
 
 // Validate a single request with text proto output.
-TEST_P(SslTapIntegrationTest, DISABLED_RequestWithTextProto) {
+TEST_P(SslTapIntegrationTest, RequestWithTextProto) {
   format_ = envoy::config::tap::v3::OutputSink::PROTO_TEXT;
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection({});
@@ -786,7 +786,7 @@ TEST_P(SslTapIntegrationTest, DISABLED_RequestWithTextProto) {
 }
 
 // Validate a single request with JSON (body as string) output. This test uses an upstream tap.
-TEST_P(SslTapIntegrationTest, DISABLED_RequestWithJsonBodyAsStringUpstreamTap) {
+TEST_P(SslTapIntegrationTest, RequestWithJsonBodyAsStringUpstreamTap) {
   upstream_tap_ = true;
   max_rx_bytes_ = 5;
   max_tx_bytes_ = 4;


### PR DESCRIPTION
The SSL_set_tlsext_status_ocsp_resp() function takes ownership of the OCSP response buffer parameter, but it was being passed the underlying buffer owned by a vector<>. This resulted in (1) an attempt to OPENSSL_free() the buffer that had been allocated by new, and (2) the vector<> attempting to free it's buffer, which had already been free'd.

Fixed by adding an OPENSSL_memdup() on the buffer.

Signed-off-by: Ted Poole <tpoole@redhat.com>
