### PR TITLE
Revert "Reinstated OCSP response expiry check"

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -737,10 +737,6 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope,
       if (!response->matchesCertificate(*tls_context_.cert_contexts_[i].cert_chain_)) {
         throw EnvoyException("OCSP response does not match its TLS certificate");
       }
-      if (response->isExpired()) {
-        ENVOY_LOG_MISC(warn, "Expired OCSP response has been loaded for the certificate chain {}",
-                       tls_context_.cert_contexts_[i].getCertChainFileName());
-      }
       tls_context_.cert_contexts_[i].ocsp_response_ = std::move(response);
     }
   }


### PR DESCRIPTION
This reverts commit e35ead8d0854db808f8e60264414b548dac92295.
Follow up to https://github.com/maistra/envoy/pull/155#discussion_r853882835

Signed-off-by: Otto van der Schaaf <ovanders@redhat.com>
