### PR TITLE
OSSM-1297: Use a remote build cache, if it exists

### DIFF
--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -15,13 +15,23 @@ export ARCH
 export BUILD_SCM_REVISION="Maistra PR #${PULL_NUMBER:-undefined}"
 export BUILD_SCM_STATUS="SHA=${PULL_PULL_SHA:-undefined}"
 
+COMMON_FLAGS="\
+    --incompatible_linkopts_to_linklibs \
+    --local_ram_resources=12288 \
+    --local_cpu_resources=6 \
+    --jobs=3 \
+    --color=no \
+"
+
+if [ -n "${BAZEL_REMOTE_CACHE}" ]; then
+  COMMON_FLAGS+=" --remote_cache=${BAZEL_REMOTE_CACHE} "
+elif [ -n "${BAZEL_DISK_CACHE}" ]; then
+  COMMON_FLAGS+=" --disk_cache=${BAZEL_DISK_CACHE} "
+fi
+
 # Build
 time bazel build \
-  --incompatible_linkopts_to_linklibs \
-  --local_ram_resources=12288 \
-  --local_cpu_resources=8 \
-  --jobs=4 \
-  --disk_cache=/bazel-cache \
+  ${COMMON_FLAGS} \
   //source/exe:envoy-static
 
 echo "Build succeeded. Binary generated:"
@@ -29,12 +39,8 @@ bazel-bin/source/exe/envoy-static --version
 
 # Run tests
 time bazel test \
-  --incompatible_linkopts_to_linklibs \
-  --local_ram_resources=12288 \
-  --local_cpu_resources=8 \
-  --jobs=4 \
+  ${COMMON_FLAGS} \
   --build_tests_only \
   --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
   --test_output=all \
-  --disk_cache=/bazel-cache \
   //test/...


### PR DESCRIPTION
Manual backport of https://github.com/maistra/envoy/pull/153