### PR TITLE
OSSM-1065: clang13 build fix for s390x

### DIFF
--- a/bazel/external/wee8-s390x.patch
+++ b/bazel/external/wee8-s390x.patch
@@ -29,3 +29,13 @@
  }
  
  declare_args() {
+--- wee8/src/builtins/s390/builtins-s390.cc
++++ wee8/src/builtins/s390/builtins-s390.cc
+@@ -648,6 +648,7 @@ void Generate_JSEntryVariant(MacroAssembler* masm, StackFrame::Type type,
+   // pop the faked function when we return.
+   Handle<Code> trampoline_code =
+       masm->isolate()->builtins()->builtin_handle(entry_trampoline);
++  USE(pushed_stack_space);
+   DCHECK_EQ(kPushedStackSpace, pushed_stack_space);
+   __ Call(trampoline_code, RelocInfo::CODE_TARGET);
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OSSM-1065
Fixed -Wunused-but-set-variable clang13 build error on s390x
Applied v8 commit https://github.com/v8/v8/commit/cf98260e462bd2c3907c8478189cd197de7d8404

Signed-off-by: Konstantin Maksimov <konstantin.maksimov@ibm.com>