### PR TITLE
[maistra-2.1] add backported fixes

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -66,6 +66,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.disable_tls_inspector_injection",
     "envoy.reloadable_features.disallow_unbounded_access_logs",
     "envoy.reloadable_features.early_errors_via_hcm",
+    "envoy.reloadable_features.enable_compression_bomb_protection",
     "envoy.reloadable_features.enable_dns_cache_circuit_breakers",
     "envoy.reloadable_features.fix_upgrade_response",
     "envoy.reloadable_features.fix_wildcard_matching",

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -754,10 +754,17 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onGoAway(
   // Even if we have active health check probe, fail it on GOAWAY and schedule new one.
   if (request_encoder_) {
     handleFailure(envoy::data::core::v3::NETWORK);
-    expect_reset_ = true;
-    request_encoder_->getStream().resetStream(Http::StreamResetReason::LocalReset);
+    // request_encoder_ can already be destroyed if the host was removed during the failure callback
+    // above.
+    if (request_encoder_ != nullptr) {
+      expect_reset_ = true;
+      request_encoder_->getStream().resetStream(Http::StreamResetReason::LocalReset);
+    }
   }
-  client_->close();
+  // client_ can already be destroyed if the host was removed during the failure callback above.
+  if (client_ != nullptr) {
+    client_->close();
+  }
 }
 
 bool GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::isHealthCheckSucceeded(
@@ -791,12 +798,17 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onRpcComplete(
   if (end_stream) {
     resetState();
   } else {
-    // resetState() will be called by onResetStream().
-    expect_reset_ = true;
-    request_encoder_->getStream().resetStream(Http::StreamResetReason::LocalReset);
+    // request_encoder_ can already be destroyed if the host was removed during the failure callback
+    // above.
+    if (request_encoder_ != nullptr) {
+      // resetState() will be called by onResetStream().
+      expect_reset_ = true;
+      request_encoder_->getStream().resetStream(Http::StreamResetReason::LocalReset);
+    }
   }
 
-  if (!parent_.reuse_connection_ || goaway) {
+  // client_ can already be destroyed if the host was removed during the failure callback above.
+  if (client_ != nullptr && (!parent_.reuse_connection_ || goaway)) {
     client_->close();
   }
 }

--- a/source/extensions/compression/gzip/common/base.h
+++ b/source/extensions/compression/gzip/common/base.h
@@ -12,7 +12,6 @@ namespace Zlib {
 /**
  * Shared code between the compressor and the decompressor.
  */
-// TODO(junr03): move to extensions tree once the compressor side is moved to extensions.
 class Base {
 public:
   Base(uint64_t chunk_size, std::function<void(z_stream*)> zstream_deleter);

--- a/source/extensions/compression/gzip/decompressor/BUILD
+++ b/source/extensions/compression/gzip/decompressor/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
+        "//source/common/runtime:runtime_features_lib",
         "//source/extensions/compression/gzip/common:zlib_base_lib",
     ],
 )

--- a/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
+++ b/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
@@ -7,6 +7,7 @@
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
+#include "common/runtime/runtime_features.h"
 
 #include "absl/container/fixed_array.h"
 
@@ -15,6 +16,16 @@ namespace Extensions {
 namespace Compression {
 namespace Gzip {
 namespace Decompressor {
+
+namespace {
+
+// How many times the output buffer is allowed to be bigger than the size of
+// accumulated input. This value is used to detect compression bombs.
+// TODO(rojkov): Re-design the Decompressor interface to handle compression
+// bombs gracefully instead of this quick solution.
+constexpr uint64_t MaxInflateRatio = 100;
+
+} // namespace
 
 ZlibDecompressorImpl::ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix)
     : ZlibDecompressorImpl(scope, stats_prefix, 4096) {}
@@ -43,12 +54,25 @@ void ZlibDecompressorImpl::init(int64_t window_bits) {
 
 void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
                                       Buffer::Instance& output_buffer) {
+  uint64_t limit = MaxInflateRatio * input_buffer.length();
+
   for (const Buffer::RawSlice& input_slice : input_buffer.getRawSlices()) {
     zstream_ptr_->avail_in = input_slice.len_;
     zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
     while (inflateNext()) {
       if (zstream_ptr_->avail_out == 0) {
         updateOutput(output_buffer);
+      }
+
+      if (Runtime::runtimeFeatureEnabled(
+              "envoy.reloadable_features.enable_compression_bomb_protection") &&
+          (output_buffer.length() > limit)) {
+        stats_.zlib_data_error_.inc();
+        ENVOY_LOG(trace,
+                  "excessive decompression ratio detected: output "
+                  "size {} for input size {}",
+                  output_buffer.length(), input_buffer.length());
+        return;
       }
     }
   }

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -148,31 +148,6 @@ const std::string& OAuth2Filter::bearerPrefix() const {
   CONSTRUCT_ON_FIRST_USE(std::string, "bearer ");
 }
 
-std::string OAuth2Filter::extractAccessToken(const Http::RequestHeaderMap& headers) const {
-  ASSERT(headers.Path() != nullptr);
-
-  // Start by looking for a bearer token in the Authorization header.
-  const Http::HeaderEntry* authorization = headers.getInline(authorization_handle.handle());
-  if (authorization != nullptr) {
-    const auto value = StringUtil::trim(authorization->value().getStringView());
-    const auto& bearer_prefix = bearerPrefix();
-    if (absl::StartsWithIgnoreCase(value, bearer_prefix)) {
-      const size_t start = bearer_prefix.length();
-      return std::string(StringUtil::ltrim(value.substr(start)));
-    }
-  }
-
-  // Check for the named query string parameter.
-  const auto path = headers.Path()->value().getStringView();
-  const auto params = Http::Utility::parseQueryString(path);
-  const auto param = params.find("token");
-  if (param != params.end()) {
-    return param->second;
-  }
-
-  return EMPTY_STRING;
-}
-
 /**
  * primary cases:
  * 1) user is signing out
@@ -181,6 +156,10 @@ std::string OAuth2Filter::extractAccessToken(const Http::RequestHeaderMap& heade
  * 4) user is unauthorized
  */
 Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
+  // Sanitize the Authorization header, since we have no way to validate its content. Also,
+  // if token forwarding is enabled, this header will be set based on what is on the HMAC cookie
+  // before forwarding the request upstream.
+  headers.removeInline(authorization_handle.handle());
 
   // The following 2 headers are guaranteed for regular requests. The asserts are helpful when
   // writing test code to not forget these important variables in mock requests
@@ -235,17 +214,7 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
     request_headers_ = &headers;
   }
 
-  // If a bearer token is supplied as a header or param, we ingest it here and kick off the
-  // user resolution immediately. Note this comes after HMAC validation, so technically this
-  // header is sanitized in a way, as the validation check forces the correct Bearer Cookie value.
-  access_token_ = extractAccessToken(headers);
-  if (!access_token_.empty()) {
-    found_bearer_token_ = true;
-    finishFlow();
-    return Http::FilterHeadersStatus::Continue;
-  }
-
-  // If no access token and this isn't the callback URI, redirect to acquire credentials.
+  // If this isn't the callback URI, redirect to acquire credentials.
   //
   // The following conditional could be replaced with a regex pattern-match,
   // if we're concerned about strict matching against the callback path.
@@ -374,18 +343,6 @@ void OAuth2Filter::onGetAccessTokenSuccess(const std::string& access_code,
 }
 
 void OAuth2Filter::finishFlow() {
-
-  // We have fully completed the entire OAuth flow, whether through Authorization header or from
-  // user redirection to the auth server.
-  if (found_bearer_token_) {
-    if (config_->forwardBearerToken()) {
-      setBearerToken(*request_headers_, access_token_);
-    }
-    config_->stats().oauth_success_.inc();
-    decoder_callbacks_->continueDecoding();
-    return;
-  }
-
   std::string token_payload;
   if (config_->forwardBearerToken()) {
     token_payload = absl::StrCat(host_, new_expires_, access_token_);
@@ -407,8 +364,8 @@ void OAuth2Filter::finishFlow() {
   const std::string cookie_tail_http_only =
       fmt::format(CookieTailHttpOnlyFormatString, new_expires_);
 
-  // At this point we have all of the pieces needed to authorize a user that did not originally
-  // have a bearer access token. Now, we construct a redirect request to return the user to their
+  // At this point we have all of the pieces needed to authorize a user.
+  // Now, we construct a redirect request to return the user to their
   // previous state and additionally set the OAuth cookies in browser.
   // The redirection should result in successfully passing this filter.
   Http::ResponseHeaderMapPtr response_headers{Http::createHeaderMap<Http::ResponseHeaderMapImpl>(
@@ -432,7 +389,6 @@ void OAuth2Filter::finishFlow() {
 
   decoder_callbacks_->encodeHeaders(std::move(response_headers), true, REDIRECT_LOGGED_IN);
   config_->stats().oauth_success_.inc();
-  decoder_callbacks_->continueDecoding();
 }
 
 void OAuth2Filter::sendUnauthorizedResponse() {

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -212,7 +212,6 @@ private:
   std::string new_expires_;
   absl::string_view host_;
   std::string state_;
-  bool found_bearer_token_{false};
   Http::RequestHeaderMap* request_headers_{nullptr};
 
   std::unique_ptr<OAuth2Client> oauth_client_;
@@ -226,7 +225,6 @@ private:
   Http::FilterHeadersStatus signOutUser(const Http::RequestHeaderMap& headers);
 
   const std::string& bearerPrefix() const;
-  std::string extractAccessToken(const Http::RequestHeaderMap& headers) const;
 };
 
 } // namespace Oauth2

--- a/source/extensions/filters/http/oauth2/oauth_client.cc
+++ b/source/extensions/filters/http/oauth2/oauth_client.cc
@@ -21,9 +21,6 @@ namespace HttpFilters {
 namespace Oauth2 {
 
 namespace {
-Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
-    authorization_handle(Http::CustomHeaders::get().Authorization);
-
 constexpr const char* GetAccessTokenBodyFormatString =
     "grant_type=authorization_code&code={0}&client_id={1}&client_secret={2}&redirect_uri={3}";
 

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -4171,6 +4171,70 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedFailFirst) {
   expectHostHealthy(true);
 }
 
+// Verify functionality when a host is removed inline with a failure via RPC that was proceeded
+// by a GOAWAY.
+TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFailViaRpcRemoveHostInCallback) {
+  setupHC();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+
+  expectSessionCreate();
+  expectHealthcheckStart(0);
+  EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, true));
+  health_checker_->start();
+
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed))
+      .WillOnce(Invoke([&](HostSharedPtr host, HealthTransition) {
+        cluster_->prioritySet().getMockHostSet(0)->hosts_ = {};
+        cluster_->prioritySet().runUpdateCallbacks(0, {}, {host});
+      }));
+  EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
+  test_sessions_[0]->codec_client_->raiseGoAway(Http::GoAwayErrorCode::NoError);
+  respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::NOT_SERVING);
+}
+
+// Verify functionality when a host is removed inline with a failure via an error GOAWAY.
+TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFailViaGoawayRemoveHostInCallback) {
+  setupHCWithUnhealthyThreshold(/*threshold=*/1);
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+
+  expectSessionCreate();
+  expectHealthcheckStart(0);
+  EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, true));
+  health_checker_->start();
+
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed))
+      .WillOnce(Invoke([&](HostSharedPtr host, HealthTransition) {
+        cluster_->prioritySet().getMockHostSet(0)->hosts_ = {};
+        cluster_->prioritySet().runUpdateCallbacks(0, {}, {host});
+      }));
+  EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
+  test_sessions_[0]->codec_client_->raiseGoAway(Http::GoAwayErrorCode::Other);
+}
+
+// Verify functionality when a host is removed inline with by a bad RPC response.
+TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFailViaBadResponseRemoveHostInCallback) {
+  setupHCWithUnhealthyThreshold(/*threshold=*/1);
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
+
+  expectSessionCreate();
+  expectHealthcheckStart(0);
+  EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, true));
+  health_checker_->start();
+
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed))
+      .WillOnce(Invoke([&](HostSharedPtr host, HealthTransition) {
+        cluster_->prioritySet().getMockHostSet(0)->hosts_ = {};
+        cluster_->prioritySet().runUpdateCallbacks(0, {}, {host});
+      }));
+  EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
+  std::unique_ptr<Http::TestResponseHeaderMapImpl> response_headers(
+      new Http::TestResponseHeaderMapImpl{{":status", "500"}});
+  test_sessions_[0]->stream_response_callbacks_->decodeHeaders(std::move(response_headers), false);
+}
+
 // Test host recovery after explicit check failure requires several successful checks.
 TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFail) {
   setupHC();

--- a/test/extensions/compression/gzip/compressor_fuzz_test.cc
+++ b/test/extensions/compression/gzip/compressor_fuzz_test.cc
@@ -72,8 +72,10 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
                                                : Envoy::Compression::Compressor::State::Flush);
     decompressor.decompress(buffer, full_output);
   }
-  RELEASE_ASSERT(full_input.toString() == full_output.toString(), "");
-  RELEASE_ASSERT(compressor.checksum() == decompressor.checksum(), "");
+  if (stats_store.counterFromString("test.zlib_data_error").value() == 0) {
+    RELEASE_ASSERT(full_input.toString() == full_output.toString(), "");
+    RELEASE_ASSERT(compressor.checksum() == decompressor.checksum(), "");
+  }
 }
 
 } // namespace Fuzz

--- a/test/extensions/compression/gzip/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/extensions/compression/gzip/decompressor/zlib_decompressor_impl_test.cc
@@ -123,6 +123,31 @@ TEST_F(ZlibDecompressorImplTest, CallingChecksum) {
   ASSERT_EQ(0, decompressor.decompression_error_);
 }
 
+// Detect excessive compression ratio by compressing a long whitespace string
+// into a very small chunk of data and decompressing it again.
+TEST_F(ZlibDecompressorImplTest, DetectExcessiveCompressionRatio) {
+  const absl::string_view ten_whitespaces = "          ";
+  Buffer::OwnedImpl buffer;
+  Extensions::Compression::Gzip::Compressor::ZlibCompressorImpl compressor;
+  compressor.init(
+      Extensions::Compression::Gzip::Compressor::ZlibCompressorImpl::CompressionLevel::Standard,
+      Extensions::Compression::Gzip::Compressor::ZlibCompressorImpl::CompressionStrategy::Standard,
+      gzip_window_bits, memory_level);
+
+  for (int i = 0; i < 1000; i++) {
+    buffer.add(ten_whitespaces);
+  }
+
+  compressor.compress(buffer, Envoy::Compression::Compressor::State::Finish);
+
+  Buffer::OwnedImpl output_buffer;
+  Stats::IsolatedStoreImpl stats_store{};
+  ZlibDecompressorImpl decompressor{stats_store, "test."};
+  decompressor.init(gzip_window_bits);
+  decompressor.decompress(buffer, output_buffer);
+  ASSERT_EQ(stats_store.counterFromString("test.zlib_data_error").value(), 1);
+}
+
 // Exercises compression and decompression by compressing some data, decompressing it and then
 // comparing compressor's input/checksum with decompressor's output/checksum.
 TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -78,7 +78,7 @@ public:
     init();
   }
 
-  void init() {
+  void init(bool forward_bearing_token = true) {
     // Set up the OAuth client
     oauth_client_ = new MockOAuth2Client();
     std::unique_ptr<OAuth2Client> oauth_client_ptr{oauth_client_};
@@ -93,7 +93,7 @@ public:
     p.mutable_redirect_path_matcher()->mutable_path()->set_exact(TEST_CALLBACK);
     p.set_authorization_endpoint("https://auth.example.com/oauth/authorize/");
     p.mutable_signout_path()->mutable_path()->set_exact("/_signout");
-    p.set_forward_bearer_token(true);
+    p.set_forward_bearer_token(forward_bearing_token);
     auto* matcher = p.add_pass_through_matcher();
     matcher->set_name(":method");
     matcher->set_exact_match("OPTIONS");
@@ -201,6 +201,50 @@ TEST_F(OAuth2Test, OAuthOkPass) {
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
       {Http::Headers::get().ForwardedProto.get(), "https"},
       {Http::CustomHeaders::get().Authorization.get(), "Bearer legit_token"},
+  };
+
+  // cookie-validation mocking
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
+
+  // Sanitized return reference mocking
+  std::string legit_token{"legit_token"};
+  EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_token));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+            filter_->decodeHeaders(mock_request_headers, false));
+
+  // Ensure that existing OAuth forwarded headers got sanitized.
+  EXPECT_EQ(mock_request_headers, expected_headers);
+
+  EXPECT_EQ(scope_.counterFromString("test.oauth_failure").value(), 0);
+  EXPECT_EQ(scope_.counterFromString("test.oauth_success").value(), 1);
+}
+
+/**
+ * Scenario: The OAuth filter receives a request to an arbitrary path with valid OAuth cookies
+ * (cookie values and validation are mocked out), but with an invalid token in the Authorization
+ * header and forwarding bearer token is disabled.
+ *
+ * Expected behavior: the filter should sanitize the Authorization header and let the request
+ * proceed.
+ */
+TEST_F(OAuth2Test, OAuthOkPassButInvalidToken) {
+  init(false /* forward_bearer_token */);
+
+  Http::TestRequestHeaderMapImpl mock_request_headers{
+      {Http::Headers::get().Path.get(), "/anypath"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+      {Http::CustomHeaders::get().Authorization.get(), "Bearer injected_malice!"},
+  };
+
+  Http::TestRequestHeaderMapImpl expected_headers{
+      {Http::Headers::get().Path.get(), "/anypath"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
   };
 
   // cookie-validation mocking
@@ -608,21 +652,12 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParameters) {
 
   EXPECT_CALL(decoder_callbacks_,
               encodeHeaders_(HeaderMapEqualRef(&second_response_headers), true));
-  EXPECT_CALL(decoder_callbacks_, continueDecoding());
 
   filter_->finishFlow();
 }
 
 TEST_F(OAuth2Test, OAuthBearerTokenFlowFromHeader) {
-  Http::TestRequestHeaderMapImpl request_headers_before{
-      {Http::Headers::get().Path.get(), "/test?role=bearer"},
-      {Http::Headers::get().Host.get(), "traffic.example.com"},
-      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
-      {Http::Headers::get().ForwardedProto.get(), "https"},
-      {Http::CustomHeaders::get().Authorization.get(), "Bearer xyz-header-token"},
-  };
-  // Expected decoded headers after the callback & validation of the bearer token is complete.
-  Http::TestRequestHeaderMapImpl request_headers_after{
+  Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/test?role=bearer"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
@@ -630,41 +665,27 @@ TEST_F(OAuth2Test, OAuthBearerTokenFlowFromHeader) {
       {Http::CustomHeaders::get().Authorization.get(), "Bearer xyz-header-token"},
   };
 
-  // Fail the validation to trigger the OAuth flow.
+  // Fail the validation.
   EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
 
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->decodeHeaders(request_headers_before, false));
-
-  // Finally, expect that the header map had OAuth information appended to it.
-  EXPECT_EQ(request_headers_before, request_headers_after);
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
 }
 
 TEST_F(OAuth2Test, OAuthBearerTokenFlowFromQueryParameters) {
-  Http::TestRequestHeaderMapImpl request_headers_before{
+  Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/test?role=bearer&token=xyz-queryparam-token"},
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
       {Http::Headers::get().ForwardedProto.get(), "https"},
-  };
-  Http::TestRequestHeaderMapImpl request_headers_after{
-      {Http::Headers::get().Path.get(), "/test?role=bearer&token=xyz-queryparam-token"},
-      {Http::Headers::get().Host.get(), "traffic.example.com"},
-      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
-      {Http::Headers::get().ForwardedProto.get(), "https"},
-      {Http::CustomHeaders::get().Authorization.get(), "Bearer xyz-queryparam-token"},
   };
 
-  // Fail the validation to trigger the OAuth flow.
+  // Fail the validation.
   EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
-
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->decodeHeaders(request_headers_before, false));
-
-  // Expected decoded headers after the callback & validation of the bearer token is complete.
-  EXPECT_EQ(request_headers_before, request_headers_after);
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
 }
 
 } // namespace Oauth2


### PR DESCRIPTION
Summary: contains three backported fixes

- oauth2: do not blindly accept requests with a token in the Authorization header 
 https://github.com/envoyproxy/envoy/commit/6b1fb93d5da933d681744ae484c8dbfaa7f56e85
- healthcheck: fix grpc inline removal crashes https://github.com/envoyproxy/envoy/commit/209bc16c5ef2d87816cf488de4a0d085f29c2bf4
- decompressors: stop decompressing upon excessive compression ratio https://github.com/envoyproxy/envoy/commit/c2a3bd494d77e3c48bac681d00832fed1e31ff49


