### PR TITLE
Add scripts to support test execution with sanitizers enabled.

### DIFF
--- a/maistra/README.md
+++ b/maistra/README.md
@@ -69,22 +69,21 @@ This will build Envoy and check that all tests pass. When this succeeds, general
 Our build flows support executing Envoy's test suite with [sanitizers](https://github.com/google/sanitizers) enabled.
 This allows one to test for memory leaks, undefined behaviour, data races, and so on.
 The easiest way to get started is to execute the examples below in the docker image pointed out above.
-We pass `CI_CONFIG=0` in this example to avoid applying some CI-specific configuration.
+We wipe the `CI` environment variable in this example to stop bazel from applying CI-specific configuration.
 
 ```sh
 # Test for undefined behaviour / leaks
-CI_CONFIG=0  maistra/test-with-asan.sh //test/common/common:base64_test
-
+CI=  maistra/test-with-asan.sh //test/common/common:base64_test
  ```
 
 ```sh
 # Test for potential data races and deadlocks
-CI_CONFIG=0  maistra/test-with-tsan.sh //test/common/common:base64_test
+CI=  maistra/test-with-tsan.sh //test/common/common:base64_test
 ```
 
 ```sh
 # Test for uninitialized memory access
-CI_CONFIG=0 maistra/test-with-msan.sh //test/common/common:base64_test
+CI= maistra/test-with-msan.sh //test/common/common:base64_test
 ```
 
 ## New versions

--- a/maistra/README.md
+++ b/maistra/README.md
@@ -69,21 +69,20 @@ This will build Envoy and check that all tests pass. When this succeeds, general
 Our build flows support executing Envoy's test suite with [sanitizers](https://github.com/google/sanitizers) enabled.
 This allows one to test for memory leaks, undefined behaviour, data races, and so on.
 The easiest way to get started is to execute the examples below in the docker image pointed out above.
-We wipe the `CI` environment variable in this example to stop bazel from applying CI-specific configuration.
 
 ```sh
 # Test for undefined behaviour / leaks
-CI=  maistra/test-with-asan.sh //test/common/common:base64_test
+maistra/test-with-asan.sh //test/common/common:base64_test
  ```
 
 ```sh
 # Test for potential data races and deadlocks
-CI=  maistra/test-with-tsan.sh //test/common/common:base64_test
+maistra/test-with-tsan.sh //test/common/common:base64_test
 ```
 
 ```sh
 # Test for uninitialized memory access
-CI= maistra/test-with-msan.sh //test/common/common:base64_test
+maistra/test-with-msan.sh //test/common/common:base64_test
 ```
 
 ## New versions

--- a/maistra/README.md
+++ b/maistra/README.md
@@ -51,6 +51,42 @@ The [run-ci.sh script](./run-ci.sh) is the one that runs on our CI (more on this
 
 Note that we changed a bunch of compilation flags, when comparing to upstream. Most (but not all) of these changes are on the [bazelrc](./bazelrc) file, which is included from the [main .bazelrc](../.bazelrc) file. Again, feel free to tweak these files during local development.
 
+## Running tests
+
+
+### Testing changes 
+
+To test run Envoy's test suite locally one can run the same script that gets used in CI:
+
+```sh
+maistra/run-ci.sh
+```
+
+This will build Envoy and check that all tests pass. When this succeeds, generally CI tests will pass as well.
+
+### Executing tests with sanitizers enabled.
+
+Our build flows support executing Envoy's test suite with [sanitizers](https://github.com/google/sanitizers) enabled.
+This allows one to test for memory leaks, undefined behaviour, data races, and so on.
+The easiest way to get started is to execute the examples below in the docker image pointed out above.
+We pass `CI_CONFIG=0` in this example to avoid applying some CI-specific configuration.
+
+```sh
+# Test for undefined behaviour / leaks
+CI_CONFIG=0  maistra/test-with-asan.sh //test/common/common:base64_test
+
+ ```
+
+```sh
+# Test for potential data races and deadlocks
+CI_CONFIG=0  maistra/test-with-tsan.sh //test/common/common:base64_test
+```
+
+```sh
+# Test for uninitialized memory access
+CI_CONFIG=0 maistra/test-with-msan.sh //test/common/common:base64_test
+```
+
 ## New versions
 
 The next version is chosen based on the version the Istio project will use. For example, if Maistra 2.3 is going to ship Istio 1.14, then, we are going to use whatever version of Envoy Istio 1.14 uses (which is 1.22). That will be our `maistra-2.3` branch.

--- a/maistra/bazelrc
+++ b/maistra/bazelrc
@@ -23,3 +23,6 @@ build:ci-config --jobs=3
 
 # Colored ouput messes with some of the logging systems in CI, so we disable that.
 build:ci-config --color=no
+
+build:ci-config --test_output=all
+build:ci-config --test_env=ENVOY_IP_TEST_VERSIONS=v4only

--- a/maistra/bazelrc
+++ b/maistra/bazelrc
@@ -1,11 +1,25 @@
+# This file is sourced in /.bazelrc, and therefore is always interpreted for all bazel invocations
+
 # FIXME: https://issues.redhat.com/browse/OSSM-1201
 build --cxxopt -w
 
 build --copt -DOPENSSL_IS_BORINGSSL=0
 build --verbose_failures
 
+# As of today we do not support QUIC/HTTP3 -- hence we exclude it from the build, always.
+build --deleted_packages=test/common/quic,test/common/quic/platform
+build "--//bazel:http3"=false
+
 # Arch-specific build flags, triggered with --config=$ARCH in bazel build command
 build:x86_64 --linkopt=-fuse-ld=lld
 build:s390x --//source/extensions/filters/common/lua:luajit2=1 --copt="-Wno-deprecated-declarations" --linkopt=-fuse-ld=gold
 build:ppc --//source/extensions/filters/common/lua:luajit2=1 --linkopt=-fuse-ld=lld
 build:aarch64 --linkopt=-fuse-ld=lld
+
+# Throttle resources to work for our CI environemt
+build:ci-config --local_ram_resources=12288
+build:ci-config --local_cpu_resources=6
+build:ci-config --jobs=3
+
+# Colored ouput messes with some of the logging systems in CI, so we disable that.
+build:ci-config --color=no

--- a/maistra/common.sh
+++ b/maistra/common.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+set -x
+
+export CC=clang CXX=clang++
+
+ARCH=$(uname -p)
+if [ "${ARCH}" = "ppc64le" ]; then
+  ARCH="ppc"
+fi
+export ARCH
+
+export BUILD_SCM_REVISION="Maistra PR #${PULL_NUMBER:-undefined}"
+export BUILD_SCM_STATUS="SHA=${PULL_PULL_SHA:-undefined}"
+export CI_CONFIG=${CI_CONFIG:-1}
+
+COMMON_FLAGS="\
+    --config=${ARCH} \
+"
+if [ "${CI_CONFIG}" -eq "1" ]; then
+  COMMON_FLAGS+=" --config=ci-config "  
+fi
+
+if [ -n "${BAZEL_REMOTE_CACHE}" ]; then
+  COMMON_FLAGS+=" --remote_cache=${BAZEL_REMOTE_CACHE} "
+elif [ -n "${BAZEL_DISK_CACHE}" ]; then
+  COMMON_FLAGS+=" --disk_cache=${BAZEL_DISK_CACHE} "
+fi

--- a/maistra/common.sh
+++ b/maistra/common.sh
@@ -14,13 +14,12 @@ export ARCH
 
 export BUILD_SCM_REVISION="Maistra PR #${PULL_NUMBER:-undefined}"
 export BUILD_SCM_STATUS="SHA=${PULL_PULL_SHA:-undefined}"
-export CI_CONFIG=${CI_CONFIG:-1}
 
 COMMON_FLAGS="\
     --config=${ARCH} \
 "
-if [ "${CI_CONFIG}" -eq "1" ]; then
-  COMMON_FLAGS+=" --config=ci-config "  
+if [ -n "${CI}" ]; then
+  COMMON_FLAGS+=" --config=ci-config " 
 fi
 
 if [ -n "${BAZEL_REMOTE_CACHE}" ]; then

--- a/maistra/common.sh
+++ b/maistra/common.sh
@@ -12,9 +12,6 @@ if [ "${ARCH}" = "ppc64le" ]; then
 fi
 export ARCH
 
-export BUILD_SCM_REVISION="Maistra PR #${PULL_NUMBER:-undefined}"
-export BUILD_SCM_STATUS="SHA=${PULL_PULL_SHA:-undefined}"
-
 COMMON_FLAGS="\
     --config=${ARCH} \
 "

--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -15,7 +15,5 @@ bazel-bin/source/exe/envoy-static --version
 time bazel test \
   ${COMMON_FLAGS} \
   --build_tests_only \
-  --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
-  --test_output=all \
   //test/...
 

--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -1,36 +1,7 @@
 #!/bin/bash
 
-set -e
-set -o pipefail
-set -x
-
-export CC=clang CXX=clang++
-
-ARCH=$(uname -p)
-if [ "${ARCH}" = "ppc64le" ]; then
-  ARCH="ppc"
-fi
-export ARCH
-
-export BUILD_SCM_REVISION="Maistra PR #${PULL_NUMBER:-undefined}"
-export BUILD_SCM_STATUS="SHA=${PULL_PULL_SHA:-undefined}"
-
-COMMON_FLAGS="\
-    --config=clang \
-    --config=${ARCH} \
-    --local_ram_resources=12288 \
-    --local_cpu_resources=6 \
-    --jobs=3 \
-    --deleted_packages=test/common/quic,test/common/quic/platform \
-    --//bazel:http3=false \
-    --color=no \
-"
-
-if [ -n "${BAZEL_REMOTE_CACHE}" ]; then
-  COMMON_FLAGS+=" --remote_cache=${BAZEL_REMOTE_CACHE} "
-elif [ -n "${BAZEL_DISK_CACHE}" ]; then
-  COMMON_FLAGS+=" --disk_cache=${BAZEL_DISK_CACHE} "
-fi
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "$DIR/common.sh"
 
 # Build
 time bazel build \

--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -3,6 +3,9 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "$DIR/common.sh"
 
+export BUILD_SCM_REVISION="Maistra PR #${PULL_NUMBER:-undefined}"
+export BUILD_SCM_STATUS="SHA=${PULL_PULL_SHA:-undefined}"
+
 # Build
 time bazel build \
   ${COMMON_FLAGS} \

--- a/maistra/test-with-asan.sh
+++ b/maistra/test-with-asan.sh
@@ -12,10 +12,6 @@
 # to specify other sanitizers, as support in our bazel setup. 
 # As of writing this, known valid values are "tsan" and "msan".
 
-# Lastly, when running this in development flows, one might want to set CI=
-# Doing so wipes ci-specific settings, which amongst other things unthrottles the build
-# to use all the available memory and cpu resources.
-
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "$DIR/common.sh"
 

--- a/maistra/test-with-asan.sh
+++ b/maistra/test-with-asan.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This script will execute Envoy's c++ unit and integration tests with
+# address sanitizer enabled. It may point out issues related to both
+# undefined behaviour as well as memory management issues (leaks).
+
+# An argument can be passed to this script which when specified will replace
+# the "//test/..." part we pass to bazel. This allows one to optionally
+# specify which tests to run.
+
+# Furthermore, while this defaults to asan, one can set the SANITIZER env var
+# to specify other sanitizers, as support in our bazel setup. 
+# As of writing this, known valid values are "tsan" and "msan".
+
+# Lastly, when running this in development flows, one might want to set BAZEL_CONFIG=
+# Doing so wipes ci-specific settings, which amongst other things unthrottles the build
+# to use all the available memoruy and cpu resources.
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "$DIR/common.sh"
+
+SANITIZER=${SANITIZER:-asan}
+BAZEL_TESTS=${1:-//test/...}
+
+FLAGS="${COMMON_FLAGS} \
+  --config=clang-${SANITIZER} \
+  --build_tests_only \
+  --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
+  --test_output=all \
+  ${BAZEL_TESTS} \
+"
+
+echo "Build tests with ${SANITIZER:asan} enabled."
+time bazel build $FLAGS
+  
+echo "Execute tests with ${SANITIZER:asan} enabled."
+time bazel test $FLAGS

--- a/maistra/test-with-asan.sh
+++ b/maistra/test-with-asan.sh
@@ -20,13 +20,10 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "$DIR/common.sh"
 
 SANITIZER=${SANITIZER:-asan}
-BAZEL_TESTS=${1:-//test/...}
+BAZEL_TESTS=${@:-//test/...}
 
 FLAGS="${COMMON_FLAGS} \
   --config=clang-${SANITIZER} \
-  --build_tests_only \
-  --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
-  --test_output=all \
   ${BAZEL_TESTS} \
 "
 

--- a/maistra/test-with-asan.sh
+++ b/maistra/test-with-asan.sh
@@ -12,9 +12,9 @@
 # to specify other sanitizers, as support in our bazel setup. 
 # As of writing this, known valid values are "tsan" and "msan".
 
-# Lastly, when running this in development flows, one might want to set BAZEL_CONFIG=
+# Lastly, when running this in development flows, one might want to set CI=
 # Doing so wipes ci-specific settings, which amongst other things unthrottles the build
-# to use all the available memoruy and cpu resources.
+# to use all the available memory and cpu resources.
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "$DIR/common.sh"
@@ -24,11 +24,14 @@ BAZEL_TESTS=${@:-//test/...}
 
 FLAGS="${COMMON_FLAGS} \
   --config=clang-${SANITIZER} \
+  -c dbg \
   ${BAZEL_TESTS} \
 "
 
-echo "Build tests with ${SANITIZER:asan} enabled."
+# We build and test in separate steps as in the past that has been observed to help
+# stabilize the build as well as test execution.
+echo "Build tests with ${SANITIZER} enabled."
 time bazel build $FLAGS
   
-echo "Execute tests with ${SANITIZER:asan} enabled."
+echo "Execute tests with ${SANITIZER} enabled."
 time bazel test $FLAGS

--- a/maistra/test-with-msan.sh
+++ b/maistra/test-with-msan.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This script will execute Envoy's c++ unit and integration tests with
+# memory sanitizer enabled. It may point out use of uninitialized memory.
+
+export SANITIZER=${SANITIZER:-msan}
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "$DIR/test-with-asan.sh"

--- a/maistra/test-with-tsan.sh
+++ b/maistra/test-with-tsan.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This script will execute Envoy's c++ unit and integration tests with
+# thread sanitizer enabled. It may point out concurrency issues like
+# races with respect to access to data shared across threads.
+
+export SANITIZER=${SANITIZER:-tsan}
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "$DIR/test-with-asan.sh"


### PR DESCRIPTION
- Refactors run-ci.sh a little bit to make it easier to use in dev flows
- Add new scripts to support executing with asan/tsan/msan enabled

Signed-off-by: Otto van der Schaaf <ovanders@redhat.com>

