### PR TITLE
test: adding flexibility to PIE string (#20462)

### DIFF
--- a/test/exe/pie_test.sh
+++ b/test/exe/pie_test.sh
@@ -13,6 +13,10 @@ if readelf -hW "${ENVOY_BIN}" | grep "Type" | grep -o "DYN (Shared object file)"
   echo "${ENVOY_BIN} is a PIE!"
   exit 0
 fi
+if readelf -hW "${ENVOY_BIN}" | grep "Type" | grep -o "DYN (Position-Independent Executable file)"; then
+  echo "${ENVOY_BIN} is a PIE!"
+  exit 0
+fi
 
 echo "${ENVOY_BIN} is not a PIE!"
 exit 1


### PR DESCRIPTION
The change is from envoy upstream https://github.com/envoyproxy/envoy/pull/20462
On s390x the output is "DYN (Position-Independent Executable file)" and the test fails for that reason.
