### PR TITLE
Make RELEASE build by default

### DIFF
--- a/maistra/bazelrc
+++ b/maistra/bazelrc
@@ -5,6 +5,7 @@ build --cxxopt -w
 
 build --copt -DOPENSSL_IS_BORINGSSL=0
 build --verbose_failures
+build -c opt
 
 # As of today we do not support QUIC/HTTP3 -- hence we exclude it from the build, always.
 build --deleted_packages=test/common/quic,test/common/quic/platform


### PR DESCRIPTION
Building and testing with optimization potentially could help to detect hidden problems. Other repos (envoyproxy/envoy and maistra/proxy) run RELEASE build by default.