### PR TITLE
OSSM-1956: a temp. fix for antlr4 crash on s390x

### DIFF
--- a/bazel/antlr_s390x_ossm_1526.patch
+++ b/bazel/antlr_s390x_ossm_1526.patch
@@ -1,0 +1,11 @@
+--- a/runtime/Cpp/runtime/src/Lexer.cpp
++++ b/runtime/Cpp/runtime/src/Lexer.cpp
+@@ -73,7 +73,7 @@
+     tokenStartCharIndex = _input->index();
+     tokenStartCharPositionInLine = getInterpreter<atn::LexerATNSimulator>()->getCharPositionInLine();
+     tokenStartLine = getInterpreter<atn::LexerATNSimulator>()->getLine();
+-    _text = "";
++    _text.clear();
+     do {
+       type = Token::INVALID_TYPE;
+       size_t ttype;

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -525,7 +525,13 @@ cc_library(
 """,
         patch_args = ["-p1"],
         # Patches ASAN violation of initialization fiasco
-        patches = ["@envoy//bazel:antlr.patch"],
+        patches = [
+            "@envoy//bazel:antlr.patch",
+            # antlr_s390x_ossm_1526.patch is a temporary workaround for antlr4 crash problem on s390x
+            # https://issues.redhat.com/browse/OSSM-1526
+            # https://github.com/antlr/antlr4/issues/3728
+            "@envoy//bazel:antlr_s390x_ossm_1526.patch"
+        ],
     )
 
 def _com_github_google_perfetto():


### PR DESCRIPTION
2.3: https://issues.redhat.com/browse/OSSM-1956
2.2: https://issues.redhat.com/browse/OSSM-1526
https://github.com/antlr/antlr4/issues/3728
a permanent fix should replace this one in the future