### PR TITLE
Small tweaks to build system

### DIFF
--- a/maistra/bazelrc
+++ b/maistra/bazelrc
@@ -6,6 +6,7 @@ build --cxxopt -w
 build --copt -DOPENSSL_IS_BORINGSSL=0
 build --verbose_failures
 build --config=clang
+build --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 
 # As of today we do not support QUIC/HTTP3 -- hence we exclude it from the build, always.
 build --deleted_packages=test/common/quic,test/common/quic/platform
@@ -26,4 +27,3 @@ build:ci-config --jobs=3
 build:ci-config --color=no
 
 build:ci-config --test_output=all
-build:ci-config --test_env=ENVOY_IP_TEST_VERSIONS=v4only

--- a/maistra/common.sh
+++ b/maistra/common.sh
@@ -14,7 +14,6 @@ export ARCH
 
 COMMON_FLAGS="\
     --config=${ARCH} \
-    --config=clang \
     --define crypto=system \
 "
 if [ -n "${CI}" ]; then

--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -18,6 +18,16 @@ time bazel build \
 echo "Build succeeded. Binary generated:"
 bazel-bin/source/exe/envoy-static --version
 
+# By default, `bazel test` command performs simultaneous
+# build and test activity.
+# The following build step helps reduce resources usage
+# by compiling tests first.
+# Build tests
+time bazel build \
+  ${COMMON_FLAGS} \
+  --build_tests_only \
+  //test/...
+
 # Run tests
 time bazel test \
   ${COMMON_FLAGS} \


### PR DESCRIPTION
- Remove duplicated flag `--config=clang` that causes a WARNING
- Move the ipv4 flag for tests to be applied everywhere, not only in CI
- Build tests before running them. This might help with CPU usages
