### PR TITLE
Add patches for Proxy WASM enabling (OSSM-1931)

### DIFF
--- a/bazel/com_github_google_flatbuffers.patch
+++ b/bazel/com_github_google_flatbuffers.patch
@@ -1,0 +1,13 @@
+diff -ruN a/include/flatbuffers/base.h b/include/flatbuffers/base.h
+--- a/include/flatbuffers/base.h	2022-09-30 18:32:00.076755650 +0200
++++ b/include/flatbuffers/base.h	2022-09-30 18:32:00.103755894 +0200
+@@ -258,6 +258,9 @@
+   #endif
+ #endif // !FLATBUFFERS_HAS_NEW_STRTOD
+ 
++// The following define added to fix OSSM-1931
++#define FLATBUFFERS_LOCALE_INDEPENDENT 0
++
+ #ifndef FLATBUFFERS_LOCALE_INDEPENDENT
+   // Enable locale independent functions {strtof_l, strtod_l,strtoll_l, strtoull_l}.
+   #if ((defined(_MSC_VER) && _MSC_VER >= 1800)            || \

--- a/bazel/com_google_absl.patch
+++ b/bazel/com_google_absl.patch
@@ -1,0 +1,13 @@
+diff -ruN a/absl/time/internal/cctz/src/time_zone_libc.cc b/absl/time/internal/cctz/src/time_zone_libc.cc
+--- a/absl/time/internal/cctz/src/time_zone_libc.cc	2022-09-30 18:32:00.167756471 +0200
++++ b/absl/time/internal/cctz/src/time_zone_libc.cc	2022-09-30 18:32:00.199756759 +0200
+@@ -27,6 +27,9 @@
+ #include "absl/time/internal/cctz/include/cctz/civil_time.h"
+ #include "absl/time/internal/cctz/include/cctz/time_zone.h"
+ 
++// The following undef added to fix OSSM-1931
++#undef __EMSCRIPTEN__
++
+ #if defined(_AIX)
+ extern "C" {
+ extern long altzone;

--- a/bazel/emsdk.patch
+++ b/bazel/emsdk.patch
@@ -1,0 +1,230 @@
+diff -ruN a/BUILD b/BUILD
+--- a/BUILD	2022-10-03 16:32:14.773453666 +0200
++++ b/BUILD	2022-10-03 16:32:14.782453757 +0200
+@@ -1,5 +1,21 @@
++
++
+ package(default_visibility = ["//visibility:public"])
+ 
++# Doesn't have any effect
++# sh_binary(
++#     name = "local_link_to_host",
++#     srcs = ["local_link_to_host.sh"],
++# )
++
++genrule(
++    name = "local_link_rule",
++    # Dummy output file, just to make genrule happy
++    outs = ["hello.txt"],
++    cmd = "/work/maistra/vendor/emsdk/local_link_to_host.sh; echo hello world >$@",
++)
++
++
+ config_setting(
+     name = "linux",
+     constraint_values = [
+@@ -32,7 +48,10 @@
+     ],
+ )
+ 
+-filegroup(name = "empty")
++filegroup(  name = "empty", 
++            srcs = ["local_link_rule"], 
++        )
++
+ 
+ alias(
+     name = "binaries",
+@@ -48,7 +67,6 @@
+ alias(
+     name = "node_modules",
+     actual = select({
+-        ":linux": "@emscripten_npm_linux//:node_modules",
+         ":macos": "@emscripten_npm_mac//:node_modules",
+         ":macos_arm64": "@emscripten_npm_mac//:node_modules",
+         ":windows": "@emscripten_npm_win//:node_modules",
+diff -ruN a/emscripten_deps.bzl b/emscripten_deps.bzl
+--- a/emscripten_deps.bzl	2022-10-03 16:32:14.773453666 +0200
++++ b/emscripten_deps.bzl	2022-10-03 16:32:14.782453757 +0200
+@@ -1,10 +1,13 @@
+ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+-load("@build_bazel_rules_nodejs//:index.bzl", "npm_install", "node_repositories")
++load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
+ load(":revisions.bzl", "EMSCRIPTEN_TAGS")
+ 
++load("@envoy//bazel:repositories.bzl", "envoy_dependencies", "BUILD_ALL_CONTENT")
++
+ def _parse_version(v):
+     return [int(u) for u in v.split(".")]
+ 
++
+ def emscripten_deps(emscripten_version = "latest"):
+     version = emscripten_version
+ 
+@@ -24,14 +27,8 @@
+     # This could potentially backfire for projects with multiple emscripten
+     # dependencies that use different emscripten versions
+     excludes = native.existing_rules().keys()
+-    if "nodejs_toolchains" not in excludes:
+-        # Node 16 is the first version that supports darwin_arm64
+-        node_repositories(
+-            node_version = "16.6.2",
+-        )
+-
+     if "emscripten_bin_linux" not in excludes:
+-        http_archive(
++       http_archive(
+             name = "emscripten_bin_linux",
+             strip_prefix = "install",
+             url = emscripten_url.format("linux", revision.hash, "", "tbz2"),
+@@ -39,6 +36,12 @@
+             build_file = "@emsdk//emscripten_toolchain:emscripten.BUILD",
+             type = "tar.bz2",
+         )
++    # nodejs is taken from the host
++    #if "nodejs_toolchains" not in excludes:
++        # # Node 16 is the first version that supports darwin_arm64
++        # node_repositories(
++        #     node_version = "16.6.2",
++        # )
+ 
+     if "emscripten_bin_mac" not in excludes:
+         http_archive(
+@@ -70,12 +73,13 @@
+             type = "zip",
+         )
+ 
+-    if "emscripten_npm_linux" not in excludes:
+-        npm_install(
+-            name = "emscripten_npm_linux",
+-            package_json = "@emscripten_bin_linux//:emscripten/package.json",
+-            package_lock_json = "@emscripten_bin_linux//:emscripten/package-lock.json",
+-        )
++    # Commented out, as it downloads  nodejs again
++    # if "emscripten_npm_linux" not in excludes:
++    #     npm_install(
++    #         name = "emscripten_npm_linux",
++    #         package_json = "@emscripten_bin_linux//:emscripten/package.json",
++    #         package_lock_json = "@emscripten_bin_linux//:emscripten/package-lock.json",
++    #     )
+ 
+     if "emscripten_npm_mac" not in excludes:
+         npm_install(
+diff -ruN a/emscripten_toolchain/BUILD.bazel b/emscripten_toolchain/BUILD.bazel
+--- a/emscripten_toolchain/BUILD.bazel	2022-10-03 16:32:14.773453666 +0200
++++ b/emscripten_toolchain/BUILD.bazel	2022-10-03 16:32:14.782453757 +0200
+@@ -14,7 +14,6 @@
+         "env.bat",
+         "@emsdk//:binaries",
+         "@emsdk//:node_modules",
+-        "@nodejs//:node_files",
+     ],
+ )
+ 
+@@ -31,7 +30,6 @@
+         "link_wrapper.py",
+         ":common-script-includes",
+         "@emsdk//:binaries",
+-        "@nodejs//:node_files",
+     ],
+ )
+ 
+@@ -41,7 +39,6 @@
+         ":compile-emscripten",
+         ":link-emscripten",
+         "@emsdk//:binaries",
+-        "@nodejs//:node_files",
+     ],
+ )
+ 
+diff -ruN a/emscripten_toolchain/crosstool.bzl b/emscripten_toolchain/crosstool.bzl
+--- a/emscripten_toolchain/crosstool.bzl	2022-10-03 16:32:14.773453666 +0200
++++ b/emscripten_toolchain/crosstool.bzl	2022-10-03 16:32:14.782453757 +0200
+@@ -911,7 +911,19 @@
+                 "-iwithsysroot" + "/include/compat",
+                 "-iwithsysroot" + "/include",
+                 "-isystem",
+-                emscripten_dir + "/lib/clang/15.0.0/include",
++                #emscripten_dir + "/lib/clang/15.0.0/include",
++                # The following added to fix OSSM-1931
++                "/opt/emsdk/system/lib/libstdcxx/include",
++                "-isystem",
++                "/opt/emsdk/system/include/compat",
++                "-isystem",
++                "/opt/emsdk/system/lib/libc/musl/include",
++                "-isystem",
++                "/opt/emsdk/system/lib/libc/musl/arch/emscripten",
++                "-isystem",
++                "/opt/emsdk/system/include",
++                "-isystem",
++                "/opt/emsdk/system/lib/libc/musl/arch/generic",
+             ],
+         ),
+         # Inputs and outputs
+@@ -1073,7 +1085,13 @@
+         emscripten_dir + "/emscripten/cache/sysroot/include/c++/v1",
+         emscripten_dir + "/emscripten/cache/sysroot/include/compat",
+         emscripten_dir + "/emscripten/cache/sysroot/include",
+-        emscripten_dir + "/lib/clang/15.0.0/include",
++        #emscripten_dir + "/lib/clang/15.0.0/include",
++        # The following added to fix OSSM-1931
++        "/opt/emsdk/system/lib/libstdcxx/include",
++        "/opt/emsdk/system/lib/libc/musl/include",
++        "/opt/emsdk/system/lib/libc/musl/arch/emscripten",
++        "/opt/emsdk/system/include",
++        "/opt/emsdk/system/lib/libc/musl/arch/generic",               
+     ]
+ 
+     artifact_name_patterns = []
+diff -ruN a/emscripten_toolchain/emscripten_config b/emscripten_toolchain/emscripten_config
+--- a/emscripten_toolchain/emscripten_config	2022-10-03 16:32:14.773453666 +0200
++++ b/emscripten_toolchain/emscripten_config	2022-10-03 16:32:14.782453757 +0200
+@@ -3,12 +3,17 @@
+ 
+ ROOT_DIR = os.environ["ROOT_DIR"]
+ EMSCRIPTEN_ROOT = os.environ["EMSCRIPTEN"]
+-BINARYEN_ROOT = ROOT_DIR + "/" + os.environ["EM_BIN_PATH"]
+-LLVM_ROOT = BINARYEN_ROOT + "/bin"
+-FROZEN_CACHE = True
++# Take binaryen and llvm stuff locally (OSSM-1931)
++#BINARYEN_ROOT = ROOT_DIR + "/" + os.environ["EM_BIN_PATH"]
++BINARYEN_ROOT = "/work/maistra/local"
++#LLVM_ROOT = BINARYEN_ROOT + "/bin"
++LLVM_ROOT = "/usr/bin"
++FROZEN_CACHE = False
+ 
+ system = platform.system()
+ 
+ machine = "arm64" if platform.machine() == "arm64" else "amd64"
+ nodejs_binary = "bin/nodejs/node.exe" if(system =="Windows") else "bin/node"
+-NODE_JS = ROOT_DIR + "/external/nodejs_{}_{}/{}".format(system.lower(), machine, nodejs_binary)
++# Take node stuff locally (OSSM-1931)
++#NODE_JS = ROOT_DIR + "/external/nodejs_{}_{}/{}".format(system.lower(), machine, nodejs_binary)
++NODE_JS = "/usr/bin/node"
+diff -ruN a/emscripten_toolchain/env.sh b/emscripten_toolchain/env.sh
+--- a/emscripten_toolchain/env.sh	2022-10-03 16:32:14.774453676 +0200
++++ b/emscripten_toolchain/env.sh	2022-10-03 16:32:14.782453757 +0200
+@@ -1,5 +1,10 @@
+ #!/bin/bash
+ 
+-export ROOT_DIR=${EXT_BUILD_ROOT:-$(pwd -P)}
+-export EMSCRIPTEN=$ROOT_DIR/$EM_BIN_PATH/emscripten
++# Modified for OSSM-1931
++#export ROOT_DIR=${EXT_BUILD_ROOT:-$(pwd -P)}
++export ROOT_DIR=${EXT_BUILD_ROOT:-$(pwd)}
++export EM_BIN_PATH=""
++#export EMSCRIPTEN=$ROOT_DIR/$EM_BIN_PATH/emscripten
++export EMSCRIPTEN="$ROOT_DIR/external/emscripten_bin_linux"
++#export EM_CONFIG=$ROOT_DIR/$EM_CONFIG_PATH
+ export EM_CONFIG=$ROOT_DIR/$EM_CONFIG_PATH
+diff -ruN a/local_link_to_host.sh b/local_link_to_host.sh
+--- a/local_link_to_host.sh	1970-01-01 01:00:00.000000000 +0100
++++ b/local_link_to_host.sh	2022-10-03 16:32:14.782453757 +0200
+@@ -0,0 +1,7 @@
++#!/bin/bash
++echo "*** local_link_to_host  ***"
++rm -f /work/maistra/local/bin/*
++ln -s /bin/node /work/maistra/local/bin/node
++ln -s /usr/bin/wasm-emscripten-finalize /work/maistra/local/bin/wasm-emscripten-finalize
++ln -s /usr/bin/wasm-opt /work/maistra/local/bin/wasm-opt
++

--- a/bazel/foreign_cc/net_zlib.patch
+++ b/bazel/foreign_cc/net_zlib.patch
@@ -1,0 +1,13 @@
+diff -ruN a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2022-09-30 18:32:00.265757354 +0200
++++ b/CMakeLists.txt	2022-09-30 18:32:00.273757426 +0200
+@@ -24,6 +24,9 @@
+ check_include_file(stdint.h    HAVE_STDINT_H)
+ check_include_file(stddef.h    HAVE_STDDEF_H)
+ 
++# Added to fix OSSM-1931
++add_definitions(-DHAVE_UNISTD_H=1)
++
+ #
+ # Check to see if we have large file support
+ #

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -219,7 +219,7 @@ def envoy_dependencies(skip_targets = []):
     external_http_archive("proxy_wasm_rust_sdk")
     _com_google_cel_cpp()
     _com_github_google_perfetto()
-    external_http_archive("com_github_google_flatbuffers")
+    _com_github_google_flatbuffers()
     external_http_archive("bazel_toolchains")
     external_http_archive("bazel_compdb")
     external_http_archive("envoy_build_tools")
@@ -438,7 +438,8 @@ def _net_zlib():
         name = "net_zlib",
         build_file_content = BUILD_ALL_CONTENT,
         patch_args = ["-p1"],
-        patches = ["@envoy//bazel/foreign_cc:zlib.patch"],
+        patches = ["@envoy//bazel/foreign_cc:zlib.patch", 
+	               "@envoy//bazel/foreign_cc:net_zlib.patch"],
     )
 
     native.bind(
@@ -669,7 +670,8 @@ def _com_google_googletest():
 def _com_google_absl():
     external_http_archive(
         name = "com_google_absl",
-        patches = ["@envoy//bazel:abseil.patch"],
+	patches = ["@envoy//bazel:abseil.patch", 
+	           "@envoy//bazel:com_google_absl.patch"],
         patch_args = ["-p1"],
     )
     native.bind(
@@ -1045,7 +1047,18 @@ def _proxy_wasm_cpp_host():
     )
 
 def _emsdk():
-    external_http_archive(name = "emsdk")
+    external_http_archive(
+        "emsdk",
+        patches = ["@envoy//bazel:emsdk.patch"],
+        patch_args = ["-p1"],
+    )
+
+def _com_github_google_flatbuffers():
+    external_http_archive(
+        "com_github_google_flatbuffers",
+	    patches = ["@envoy//bazel:com_github_google_flatbuffers.patch"],
+        patch_args = ["-p1"],
+    )
 
 def _com_github_google_jwt_verify():
     external_http_archive("com_github_google_jwt_verify")


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
