### PR TITLE
Fix OSSM-1803: tls_inspector_integration_test FAILED

### DIFF
--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
@@ -171,13 +171,14 @@ TEST_P(TlsInspectorIntegrationTest, ContinueOnListenerTimeout) {
 }
 
 // The `JA3` fingerprint is correct in the access log.
-// FIXME https://issues.redhat.com/browse/OSSM-1803
-TEST_P(TlsInspectorIntegrationTest, DISABLED_JA3FingerprintIsSet) {
+// Fingerprint and MD5 values have been changed changed to fix the following issue:
+// https://issues.redhat.com/browse/OSSM-1803
+TEST_P(TlsInspectorIntegrationTest, JA3FingerprintIsSet) {
   // These TLS options will create a client hello message with
   // `JA3` fingerprint:
-  //   `771,49199,23-65281-10-11-35-16-13,23,0`
+  //   `771,49199-255,11-10-35-16-22-23-13,23,0-1-2`
   // MD5 hash:
-  //   `71d1f47d1125ac53c3c6a4863c087cfe`
+  //   `54619c7296adab310ed514d06812d95f`
   Ssl::ClientSslTransportOptions ssl_options;
   ssl_options.setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"});
   ssl_options.setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);
@@ -187,7 +188,7 @@ TEST_P(TlsInspectorIntegrationTest, DISABLED_JA3FingerprintIsSet) {
                    /*enable_`ja3`_fingerprinting=*/true);
   client_->close(Network::ConnectionCloseType::NoFlush);
   EXPECT_THAT(waitForAccessLog(listener_access_log_name_),
-              testing::Eq("71d1f47d1125ac53c3c6a4863c087cfe"));
+              testing::Eq("54619c7296adab310ed514d06812d95f"));
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, TlsInspectorIntegrationTest,


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
