### PR TITLE
OSSM-2208: SSL handshake may fail with invalid OCSP response

### DIFF
--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -6053,9 +6053,12 @@ TEST_P(SslSocketTest, TestConnectionFailsWhenCertIsMustStapleAndResponseExpired)
 // https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_cert_cb.html) and check OCSP response
 // validity then. Using this callback raises a question of cert chain compatibility with the client
 // side and how to handle it.
-TEST_P(SslSocketTest, DISABLED_TestFilterMultipleCertsFilterByOcspPolicyFallbackOnFirst) {
+TEST_P(SslSocketTest, TestFilterMultipleCertsFilterByOcspPolicyFallbackOnFirst) {
   const std::string server_ctx_yaml = R"EOF(
   common_tls_context:
+    tls_params:
+      cipher_suites:
+      - AES128-GCM-SHA256
     tls_certificates:
     - certificate_chain:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/ocsp/test_data/good_cert.pem"


### PR DESCRIPTION
Signed-off-by: Dario dcillera@redhat.com
Commit Message: OSSM-2208 fixing
Additional Description: Enable TestFilterMultipleCertsFilterByOcspPolicyFallbackOnFirst test and add  a cipher-suite on server side configuration as done in the upstream.
Risk Level: Low
Testing: Done