### PR TITLE
[maistra-2.4] Use local python instead of bazel toolchain python

### DIFF
--- a/bazel/python_dependencies.bzl
+++ b/bazel/python_dependencies.bzl
@@ -1,5 +1,5 @@
 load("@rules_python//python:pip.bzl", "pip_install", "pip_parse")
-load("@python3_10//:defs.bzl", "interpreter")
+interpreter = None
 
 def envoy_python_dependencies():
     pip_parse(


### PR DESCRIPTION
After commit https://github.com/envoyproxy/envoy/pull/20432 python interpreter from rules_python bazel toolchain is used instead of the local python. The problem is that there is no s390x support (as well as p) in rules_python repos: https://github.com/bazelbuild/rules_python/blob/main/python/versions.bzl
https://github.com/indygreg/python-build-standalone/releases
and therefore bazel build fails on s390x `'@python3_10//': No platform declared for host OS linux on arch s390x`.