### PR TITLE
Disable the RandomizeFirstAnswerTest test

### DIFF
--- a/test/extensions/filters/udp/dns_filter/dns_filter_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_test.cc
@@ -1845,7 +1845,8 @@ TEST_F(DnsFilterTest, InvalidShortBufferTest) {
   EXPECT_EQ(1, config_->stats().downstream_rx_invalid_queries_.value());
 }
 
-TEST_F(DnsFilterTest, RandomizeFirstAnswerTest) {
+// FIXME (Maistra): See https://github.com/envoyproxy/envoy/pull/24330
+TEST_F(DnsFilterTest, DISABLED_RandomizeFirstAnswerTest) {
   InSequence s;
 
   setup(forward_query_off_config);


### PR DESCRIPTION
The work on commit d032ce917328e388d40c3fe5ba1a49c3b570486d had not been applied to 2.3.

