### PR TITLE
OSSM-3267: migrate cpu and ram flags to env variables

### DIFF
--- a/maistra/bazelrc
+++ b/maistra/bazelrc
@@ -18,11 +18,6 @@ build:s390x --//source/extensions/filters/common/lua:luajit2=1 --copt="-Wno-depr
 build:ppc --//source/extensions/filters/common/lua:luajit2=1 --linkopt=-fuse-ld=lld
 build:aarch64 --linkopt=-fuse-ld=lld
 
-# Throttle resources to work for our CI environemt
-build:ci-config --local_ram_resources=12288
-build:ci-config --local_cpu_resources=6
-build:ci-config --jobs=3
-
 # Colored ouput messes with some of the logging systems in CI, so we disable that.
 build:ci-config --color=no
 

--- a/maistra/common.sh
+++ b/maistra/common.sh
@@ -18,6 +18,13 @@ COMMON_FLAGS="\
 "
 if [ -n "${CI}" ]; then
   COMMON_FLAGS+=" --config=ci-config " 
+
+  # Throttle resources to work for our CI environemt
+  LOCAL_CPU_RESOURCES="${LOCAL_CPU_RESOURCES:-6}"
+  LOCAL_RAM_RESOURCES="${LOCAL_RAM_RESOURCES:-12288}"
+
+  COMMON_FLAGS+=" --local_cpu_resources=${LOCAL_CPU_RESOURCES} "
+  COMMON_FLAGS+=" --local_ram_resources=${LOCAL_RAM_RESOURCES} "
 fi
 
 if [ -n "${BAZEL_REMOTE_CACHE}" ]; then


### PR DESCRIPTION
This PR is for migrating maistra prow jobs to Openshift CI jobs. It replaces the hard-coded CI cpu and RAM resources value with environment variables so that we can define and use more resources later.