### PR TITLE
migrate prow jobs and add back --jobs config

### DIFF
--- a/maistra/bazelrc
+++ b/maistra/bazelrc
@@ -18,11 +18,6 @@ build:s390x --//source/extensions/filters/common/lua:luajit2=1 --copt="-Wno-depr
 build:ppc --//source/extensions/filters/common/lua:luajit2=1 --linkopt=-fuse-ld=lld
 build:aarch64 --linkopt=-fuse-ld=lld
 
-# Throttle resources to work for our CI environemt
-build:ci-config --local_ram_resources=12288
-build:ci-config --local_cpu_resources=6
-build:ci-config --jobs=3
-
 # Colored ouput messes with some of the logging systems in CI, so we disable that.
 build:ci-config --color=no
 

--- a/maistra/common.sh
+++ b/maistra/common.sh
@@ -22,9 +22,11 @@ if [ -n "${CI}" ]; then
   # Throttle resources to work for our CI environemt
   LOCAL_CPU_RESOURCES="${LOCAL_CPU_RESOURCES:-6}"
   LOCAL_RAM_RESOURCES="${LOCAL_RAM_RESOURCES:-12288}"
+  LOCAL_JOBS="${LOCAL_JOBS:-3}"
 
   COMMON_FLAGS+=" --local_cpu_resources=${LOCAL_CPU_RESOURCES} "
   COMMON_FLAGS+=" --local_ram_resources=${LOCAL_RAM_RESOURCES} "
+  COMMON_FLAGS+=" --jobs=${LOCAL_JOBS} "
 fi
 
 if [ -n "${BAZEL_REMOTE_CACHE}" ]; then

--- a/maistra/common.sh
+++ b/maistra/common.sh
@@ -18,6 +18,13 @@ COMMON_FLAGS="\
 "
 if [ -n "${CI}" ]; then
   COMMON_FLAGS+=" --config=ci-config " 
+
+  # Throttle resources to work for our CI environemt
+  LOCAL_CPU_RESOURCES="${LOCAL_CPU_RESOURCES:-6}"
+  LOCAL_RAM_RESOURCES="${LOCAL_RAM_RESOURCES:-12288}"
+
+  COMMON_FLAGS+=" --local_cpu_resources=${LOCAL_CPU_RESOURCES} "
+  COMMON_FLAGS+=" --local_ram_resources=${LOCAL_RAM_RESOURCES} "
 fi
 
 if [ -n "${BAZEL_REMOTE_CACHE}" ]; then


### PR DESCRIPTION
This PR is for migrating maistra prow jobs to OpenShift CI jobs. 
In the previous PR, we replaced the hard-coded resource values with environment variables and also removed the --jobs bazelrc config. However, that change breaks the OpenShift CI job run.

One possible failure analysis :  
Without --jobs config, bazel will start the number of jobs threads as many as the number of CPU cores on the node. (e.g. 32 CPU , 32 job threads) However, the OCP node also need CPU to run some OCP component such as kube proxy. That causes resources conflicts. The last bazel job thread has no more CPU resource to run when the CPU is occupied by an OCP component process on the node.