### PR TITLE
Reinstated luajit2 package (removed by c08b605d87)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -182,6 +182,7 @@ def envoy_dependencies(skip_targets = []):
     _com_github_libevent_libevent()
     _com_github_luajit_luajit()
     _com_github_moonjit_moonjit()
+    _com_github_luajit2_luajit2()
     _com_github_nghttp2_nghttp2()
     _com_github_skyapm_cpp2sky()
     _com_github_nodejs_http_parser()
@@ -1063,6 +1064,20 @@ def _com_github_moonjit_moonjit():
     native.bind(
         name = "moonjit",
         actual = "@envoy//bazel/foreign_cc:moonjit",
+    )
+
+def _com_github_luajit2_luajit2():
+    external_http_archive(
+        name = "com_github_luajit2_luajit2",
+        build_file_content = BUILD_ALL_CONTENT,
+        patches = ["@envoy//bazel/foreign_cc:luajit2.patch"],
+        patch_args = ["-p1"],
+        patch_cmds = ["chmod u+x build.py"],
+    )
+
+    native.bind(
+        name = "luajit2",
+        actual = "@envoy//bazel/foreign_cc:luajit2",
     )
 
 def _com_github_google_tcmalloc():


### PR DESCRIPTION
It looks like commit c08b605d87 accidentally omitted/removed the luajit2 package details from `bazel/repositories.bzl`, which was causing proxy's `update-deps.sh` script to fail.