### PR TITLE
[Maistra 2.4] OSSM-2208: With multiple cert chains, SSL handshake may fail 

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -993,19 +993,27 @@ OcspStapleAction ServerContextImpl::ocspStapleAction(const CertContext& cert_con
 
 int ServerContextImpl::handleOcspStapling(SSL* ssl, void*) {
   const bool client_ocsp_capable = isClientOcspCapable(ssl);
-  // returns server cert selected for this connection
-  // see https://www.openssl.org/docs/man1.1.1/man3/SSL_set_tlsext_status_ocsp_resp.html
-  // for details
-  auto* selected_cert = SSL_get_certificate(ssl);
-  const auto& cert_context = certificateContext(selected_cert);
-  auto ocsp_staple_action = ocspStapleAction(cert_context, client_ocsp_capable);
+  
+  // Loop on all certificates to find at least a good one
+  const CertContext* selected_cert_context = nullptr;
+  auto  ocsp_staple_action = OcspStapleAction::Fail;
+  for(const auto& cert_context : tls_context_.cert_contexts_) {
+    RELEASE_ASSERT(SSL_select_current_cert(ssl,cert_context.cert_chain_.get()),
+		  "SSL_select_current_cert() failure");
+    ocsp_staple_action = ocspStapleAction(cert_context, client_ocsp_capable);
+    if (ocsp_staple_action == OcspStapleAction::Fail) {
+      continue;
+    }
+    selected_cert_context = &cert_context;
+    break;
+  }
 
   switch (ocsp_staple_action) {
   case OcspStapleAction::Staple: {
     // We avoid setting the OCSP response if the client didn't request it, but doing so is safe.
-    RELEASE_ASSERT(cert_context.ocsp_response_,
+    RELEASE_ASSERT(selected_cert_context->ocsp_response_,
                    "OCSP response must be present under OcspStapleAction::Staple");
-    const std::vector<uint8_t>& raw_bytes = cert_context.ocsp_response_->rawBytes();
+    const std::vector<uint8_t>& raw_bytes = selected_cert_context->ocsp_response_->rawBytes();
     const std::size_t raw_bytes_size = raw_bytes.size();
     unsigned char* raw_bytes_copy = static_cast<unsigned char *>(OPENSSL_memdup(raw_bytes.data(), raw_bytes_size));
     if (raw_bytes_copy == nullptr) { 
@@ -1027,7 +1035,6 @@ int ServerContextImpl::handleOcspStapling(SSL* ssl, void*) {
   case OcspStapleAction::ClientNotCapable:
     return SSL_TLSEXT_ERR_NOACK;
   }
-
   return SSL_TLSEXT_ERR_OK;
 }
 

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -6332,15 +6332,7 @@ TEST_P(SslSocketTest, TestConnectionFailsWhenCertIsMustStapleAndResponseExpired)
   testUtil(test_options.setExpectedServerStats("ssl.ocsp_staple_failed").enableOcspStapling());
 }
 
-// TODO (dmitri-d) we currently rely on OpenSSL to setup server-side certificate chain to use.
-// OpenSSL selection process doesn't take into account presence and status of an OCSP response.
-// This test failure under OpenSSL as only one of the configured certificate chains has a valid
-// OSCP response, which is expected to be used.
-// A possible approach is to use a cert_cb (see
-// https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_cert_cb.html) and check OCSP response
-// validity then. Using this callback raises a question of cert chain compatibility with the client
-// side and how to handle it.
-TEST_P(SslSocketTest, DISABLED_TestFilterMultipleCertsFilterByOcspPolicyFallbackOnFirst) {
+TEST_P(SslSocketTest, TestFilterMultipleCertsFilterByOcspPolicyFallbackOnFirst) {
   const std::string server_ctx_yaml = R"EOF(
   common_tls_context:
     tls_params:


### PR DESCRIPTION
OSSM-2208: With multiple cert chains, SSL handshake may fail if one with invalid OCSP response is selected

