### PR TITLE
Allow upstream to receive x-envoy-original-path headers (#26649)

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -33,6 +33,8 @@ Bug Fixes
   ``:scheme``, and ``:path``; or pseudo-header fields after regular header fields; or undefined pseudo-headers.
 * lua: lua coroutine should not execute after local reply is sent.
 * oauth: fixed a bug where the oauth2 filter would crash if it received a redirect URL without a state query param set.
+* http: amend the fix for ``x-envoy-original-path`` so it removes the header only at edge.
+  Previously this would also remove the header at any Envoy instance upstream of an external request, including an Envoy instance that added the header.
 
 Removed Config or Runtime
 -------------------------

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -745,7 +745,7 @@ TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("50.0.0.1"));
-  ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
+  EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
   route_config_.internal_only_headers_.push_back(LowerCaseString("custom_header"));
   TestRequestHeaderMapImpl headers{{"x-envoy-decorator-operation", "foo"},
                                    {"x-envoy-downstream-service-cluster", "foo"},
@@ -768,6 +768,7 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
   EXPECT_EQ("50.0.0.1", headers.get_("x-envoy-external-address"));
   EXPECT_FALSE(headers.has("x-envoy-decorator-operation"));
   EXPECT_FALSE(headers.has("x-envoy-downstream-service-cluster"));
+  EXPECT_FALSE(headers.has("x-envoy-original-path"));
   EXPECT_FALSE(headers.has("x-envoy-hedge-on-per-try-timeout"));
   EXPECT_FALSE(headers.has("x-envoy-retriable-status-codes"));
   EXPECT_FALSE(headers.has("x-envoy-retry-on"));
@@ -779,23 +780,55 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
   EXPECT_FALSE(headers.has("x-envoy-expected-rq-timeout-ms"));
   EXPECT_FALSE(headers.has("x-envoy-ip-tags"));
   EXPECT_FALSE(headers.has("x-envoy-original-url"));
-  EXPECT_FALSE(headers.has("x-envoy-original-path"));
   EXPECT_FALSE(headers.has("custom_header"));
 }
 
-// A request that is from an external address, but does not use remote address, should pull the
-// address from XFF.
+// A request that does not use remote address and is from an external address should pull the
+// external address from x-forwarded-for, and should not remove only-edge-sanitized headers.
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestDontUseRemote) {
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
-      std::make_shared<Network::Address::Ipv4Instance>("60.0.0.2"));
-  ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(false));
+      std::make_shared<Network::Address::Ipv4Instance>("50.0.0.1"));
+  EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(false));
+  route_config_.internal_only_headers_.push_back(LowerCaseString("custom_header"));
   TestRequestHeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},
-                                   {"x-forwarded-for", "60.0.0.1"}};
+                                   {"x-forwarded-for", "60.0.0.1"},
+                                   {"x-envoy-decorator-operation", "foo"},
+                                   {"x-envoy-downstream-service-cluster", "foo"},
+                                   {"x-envoy-hedge-on-per-try-timeout", "foo"},
+                                   {"x-envoy-retriable-status-codes", "123,456"},
+                                   {"x-envoy-retry-on", "foo"},
+                                   {"x-envoy-retry-grpc-on", "foo"},
+                                   {"x-envoy-max-retries", "foo"},
+                                   {"x-envoy-upstream-alt-stat-name", "foo"},
+                                   {"x-envoy-upstream-rq-timeout-alt-response", "204"},
+                                   {"x-envoy-upstream-rq-timeout-ms", "foo"},
+                                   {"x-envoy-expected-rq-timeout-ms", "10"},
+                                   {"x-envoy-ip-tags", "bar"},
+                                   {"x-envoy-original-url", "my_url"},
+                                   {"x-envoy-original-path", "/my_path"},
+                                   {"custom_header", "foo"}};
 
   EXPECT_EQ((MutateRequestRet{"60.0.0.1:0", false, Tracing::Reason::NotTraceable}),
             callMutateRequestHeaders(headers, Protocol::Http2));
+  // Expected external address is the one from the header, not the one from immediate upstream,
+  // because useRemoteAddress is false.
   EXPECT_EQ("60.0.0.1", headers.get_("x-envoy-external-address"));
   EXPECT_EQ("60.0.0.1", headers.get_("x-forwarded-for"));
+  EXPECT_TRUE(headers.has("x-envoy-decorator-operation"));
+  EXPECT_TRUE(headers.has("x-envoy-downstream-service-cluster"));
+  EXPECT_TRUE(headers.has("x-envoy-original-path"));
+  EXPECT_FALSE(headers.has("x-envoy-hedge-on-per-try-timeout"));
+  EXPECT_FALSE(headers.has("x-envoy-retriable-status-codes"));
+  EXPECT_FALSE(headers.has("x-envoy-retry-on"));
+  EXPECT_FALSE(headers.has("x-envoy-retry-grpc-on"));
+  EXPECT_FALSE(headers.has("x-envoy-max-retries"));
+  EXPECT_FALSE(headers.has("x-envoy-upstream-alt-stat-name"));
+  EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-alt-response"));
+  EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
+  EXPECT_FALSE(headers.has("x-envoy-expected-rq-timeout-ms"));
+  EXPECT_FALSE(headers.has("x-envoy-ip-tags"));
+  EXPECT_FALSE(headers.has("x-envoy-original-url"));
+  EXPECT_FALSE(headers.has("custom_header"));
 }
 
 // Verify that if XFF is invalid we fall back to remote address, even if it is a pipe.


### PR DESCRIPTION
Cherry picked fix for a previous fix that was incomplete.

Without this fix, the proxy test `istio.io/proxy/test/envoye2e/stackdriver_plugin:TestStackdriverPayload` was failing.