### PR TITLE
[MAISTRA-2.3]  OSSM-1956: Restore s390x fix for quiche (#210)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -898,6 +898,8 @@ def _com_github_google_quiche():
     external_http_archive(
         name = "com_github_google_quiche",
         build_file = "@envoy//bazel/external:quiche.BUILD",
+        patches = ["@envoy//bazel/external:quiche-s390x-support.patch"],
+        patch_args = ["-p1"],
     )
     native.bind(
         name = "quiche_common_platform",


### PR DESCRIPTION
Fixing has been restored to solve issues in s390x.
The fix had been lost during merge process from the upstream.
