### PR TITLE
Added support for setting Bazel's --experimental_remote_downloader option

### DIFF
--- a/maistra/common.sh
+++ b/maistra/common.sh
@@ -34,3 +34,7 @@ if [ -n "${BAZEL_REMOTE_CACHE}" ]; then
 elif [ -n "${BAZEL_DISK_CACHE}" ]; then
   COMMON_FLAGS+=" --disk_cache=${BAZEL_DISK_CACHE} "
 fi
+
+if [ -n "${BAZEL_EXPERIMENTAL_REMOTE_DOWNLOADER}" ]; then
+  COMMON_FLAGS+=" --experimental_remote_downloader=${BAZEL_EXPERIMENTAL_REMOTE_DOWNLOADER}"
+fi


### PR DESCRIPTION
This is beneficial when using the [buchgr/bazel-remote](https://github.com/buchgr/bazel-remote) cache, to reduce the number of external downloads over the internet, and therefore speed up builds.