### PR TITLE
[Maistra 2.4] Re-enable signal_tests and async_file_handle_thread_pool_test

### DIFF
--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -37,5 +37,5 @@ time bazel test \
   --build_tests_only \
   -- \
   //test/... \
-  -//test/server:listener_manager_impl_quic_only_test \
-  -//test/common/signal:signals_test 
+  -//test/server:listener_manager_impl_quic_only_test
+

--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -38,5 +38,4 @@ time bazel test \
   -- \
   //test/... \
   -//test/server:listener_manager_impl_quic_only_test \
-  -//test/extensions/common/async_files:async_file_handle_thread_pool_test \
   -//test/common/signal:signals_test 


### PR DESCRIPTION
Re-enable tests (no more reproducible in Prow):
- signal_tests (OSSM-2038: "//test/common/signal:signals_test failure in 2.4") ;
- async_file_handle_thread_pool_test (OSSM-2037: "[envoy] LinkCreatesNamedFile test failure in 2.4").