### PR TITLE
OSSM-4326 Remove stray console output

### DIFF
--- a/maistra/common.sh
+++ b/maistra/common.sh
@@ -23,6 +23,11 @@ if [ -n "${CI}" ]; then
   LOCAL_RAM_RESOURCES="${LOCAL_RAM_RESOURCES:-12288}"
   LOCAL_JOBS="${LOCAL_JOBS:-3}"
 
+  # Reduce resource usage to 2/3 of what's specified
+  LOCAL_CPU_RESOURCES=$((${LOCAL_CPU_RESOURCES} / 3 * 2))
+  LOCAL_RAM_RESOURCES=$((${LOCAL_RAM_RESOURCES} / 3 * 2))
+  LOCAL_JOBS=$((${LOCAL_JOBS} / 3 * 2))
+
   COMMON_FLAGS+=" --local_cpu_resources=${LOCAL_CPU_RESOURCES} "
   COMMON_FLAGS+=" --local_ram_resources=${LOCAL_RAM_RESOURCES} "
   COMMON_FLAGS+=" --jobs=${LOCAL_JOBS} "

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -11,7 +11,6 @@ bool isRuntimeFeature(absl::string_view feature) {
 }
 
 bool runtimeFeatureEnabled(absl::string_view feature) {
-  std::cout << "----------- Testing for feature : " << feature << std::endl;
   ASSERT(isRuntimeFeature(feature));
   if (Runtime::LoaderSingleton::getExisting()) {
     return Runtime::LoaderSingleton::getExisting()->threadsafeSnapshot()->runtimeFeatureEnabled(


### PR DESCRIPTION
Following from #285, this PR removes a stray console debug statement that wasn't spotted during the review