### PR TITLE
[maistra-2.4] OSSM-5850: ext_authz: ensure both raw body/body will be used for http authorization request (#27228)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -11,6 +11,11 @@ bug_fixes:
   area: oauth2
   change: |
     fixed a bug when passthrough header was matched, envoy would always remove the authorization header. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.oauth_header_passthrough_fix`` to false.
+- area: ext_authz
+  change: |
+    Fix a bug where the ext_authz filter will ignore the request body when the
+    :ref:`pack_as_bytes <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.BufferSettings.pack_as_bytes>` is set to true and
+    HTTP authorization service is configured.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -235,7 +235,13 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
   callbacks_ = &callbacks;
 
   Http::RequestHeaderMapPtr headers;
-  const uint64_t request_length = request.attributes().request().http().body().size();
+
+  const auto& http_request = request.attributes().request().http();
+  const auto& http_request_body =
+      http_request.body().empty() ? http_request.raw_body() : http_request.body();
+
+  uint64_t request_length = http_request_body.size();
+
   if (request_length > 0) {
     headers = Http::createHeaderMap<Http::RequestHeaderMapImpl>(
         {{Http::Headers::get().ContentLength, std::to_string(request_length)}});
@@ -243,7 +249,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
     headers = Http::createHeaderMap<Http::RequestHeaderMapImpl>(lengthZeroHeader());
   }
 
-  for (const auto& header : request.attributes().request().http().headers()) {
+  for (const auto& header : http_request.headers()) {
     const Http::LowerCaseString key{header.first};
     // Skip setting content-length header since it is already configured at initialization.
     if (key == Http::Headers::get().ContentLength) {
@@ -264,7 +270,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
   Http::RequestMessagePtr message =
       std::make_unique<Envoy::Http::RequestMessageImpl>(std::move(headers));
   if (request_length > 0) {
-    message->body().add(request.attributes().request().http().body());
+    message->body().add(http_request_body);
   }
 
   const std::string& cluster = config_->cluster();

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -148,12 +148,22 @@ public:
     client_->onSuccess(async_request_, std::move(http_response));
   }
 
-  Http::RequestMessagePtr sendRequest(absl::node_hash_map<std::string, std::string>&& headers) {
+  Http::RequestMessagePtr sendRequest(absl::node_hash_map<std::string, std::string>&& headers,
+                                      const std::string body_content = EMPTY_STRING,
+                                      bool use_raw_body = false) {
     envoy::service::auth::v3::CheckRequest request{};
     auto mutable_headers =
         request.mutable_attributes()->mutable_request()->mutable_http()->mutable_headers();
     for (const auto& header : headers) {
       (*mutable_headers)[header.first] = header.second;
+    }
+
+    if (use_raw_body) {
+      *request.mutable_attributes()->mutable_request()->mutable_http()->mutable_raw_body() =
+          body_content;
+    } else {
+      *request.mutable_attributes()->mutable_request()->mutable_http()->mutable_body() =
+          body_content;
     }
 
     Http::RequestMessagePtr message_ptr;
@@ -260,6 +270,22 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithPathRewrite) {
   Http::RequestMessagePtr message_ptr = sendRequest({{":path", "/foo"}, {"foo", "bar"}});
 
   EXPECT_EQ(message_ptr->headers().getPathValue(), "/bar/foo");
+}
+
+// Verify request body is set correctly when the normal body is empty and raw body is set.
+TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithRawBody) {
+  Http::RequestMessagePtr message_ptr =
+      sendRequest({{":path", "/foo"}, {"foo", "bar"}}, "raw_body", true);
+
+  EXPECT_EQ(message_ptr->bodyAsString(), "raw_body");
+}
+
+// Verify request body is set correctly when the normal body is set and raw body is empty.
+TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithBody) {
+  Http::RequestMessagePtr message_ptr =
+      sendRequest({{":path", "/foo"}, {"foo", "bar"}}, "body", false);
+
+  EXPECT_EQ(message_ptr->bodyAsString(), "body");
 }
 
 // Test the client when a request contains Content-Length greater than 0.


### PR DESCRIPTION
This is a backport of an upstream bug fix to ext_authz, which does not pass a request body to an authorization server when `Content-Type: multipart/form-data` and `pack_as_bytes: true`.