### PR TITLE
Fixed ppc64le proxy build issue for go-protoc-bin

### DIFF
--- a/bazel/rules_go.patch
+++ b/bazel/rules_go.patch
@@ -28,6 +28,12 @@ index 91748eda..c1aeb91e 100644
              outputs = [out, gopath, gocache],
              mnemonic = "GoToolchainBinaryBuild",
          )
+# Proxy build failed for ppc64le, as ppc64(Big endian) is getting picked for cpu value which was added
+# https://github.com/bazelbuild/rules_go/pull/3336 which is causing failures on ppc64le.
+# And changes for rules_go, is still under review from community.
+# See:
+#  - https://github.com/bazelbuild/rules_go/issues/3626
+# So adding temporary changes for maistra/proxy 2.5 build failures, which can be removed after resolving
 diff --git a/go/private/platforms.bzl b/go/private/platforms.bzl
 index 664f7aed..ef5319a4 100644
 --- a/go/private/platforms.bzl

--- a/bazel/rules_go.patch
+++ b/bazel/rules_go.patch
@@ -28,3 +28,15 @@ index 91748eda..c1aeb91e 100644
              outputs = [out, gopath, gocache],
              mnemonic = "GoToolchainBinaryBuild",
          )
+diff --git a/go/private/platforms.bzl b/go/private/platforms.bzl
+index 664f7aed..ef5319a4 100644
+--- a/go/private/platforms.bzl
++++ b/go/private/platforms.bzl
+@@ -30,7 +30,6 @@ BAZEL_GOARCH_CONSTRAINTS = {
+     "amd64": "@platforms//cpu:x86_64",
+     "arm": "@platforms//cpu:armv7",
+     "arm64": "@platforms//cpu:aarch64",
+-    "ppc64": "@platforms//cpu:ppc",
+     "ppc64le": "@platforms//cpu:ppc",
+     "s390x": "@platforms//cpu:s390x",
+ }


### PR DESCRIPTION
Fixed proxy build for maistra 2.5 for Ppc64le

```
bazel-out/ppc-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_go/go/tools/builders/go-protoc/go-protoc-bin: bazel-out/ppc-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_go/go/tools/builders/go-protoc/go-protoc-bin: cannot execute binary file
Target //:envoy failed to build
ERROR: /root/.cache/bazel/_bazel_root/8db9a95ef420fca632dcc10027fd7a66/external/envoy_api/envoy/service/discovery/v3/BUILD:7:18 Middleman _middlemen/@envoy_Uapi_S_Senvoy_Sservice_Sdiscovery_Sv3_Cpkg_Ucc_Uproto-cc_library-compile failed: (Exit 126): go-protoc-bin failed: error executing command (from target @com_envoyproxy_protoc_gen_validate//validate:validate_go_proto)
```


Result:
```
Build succeeded. Binary generated:
+ bazel-bin/envoy --version

bazel-bin/envoy  version: ae3bbc4313b45af63777a2588388796d74221cfd/1.26.8-dev/Modified/RELEASE/OpenSSL
```
