### PR TITLE
[MAISTRA-2.5] CI TIMEOUT workaround: use bazel "flaky_test_attempt" option

### DIFF
--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -30,46 +30,13 @@ time bazel build \
   //test/... \
   -//test/extensions/listener_managers/listener_manager:listener_manager_impl_quic_only_test
 
-# These tests can fail with TIME OUT if run as part of batch
-extra_tests=(
-    //test/exe:main_common_test \
-    //test/server:guarddog_impl_test \
-    //test/common/stream_info:filter_state_impl_test \
-    //test/common/common:assert_enabled_in_release_test \
-    //test/common/common:assert_test \
-    //test/common/upstream:conn_pool_map_impl_test \
-    //test/common/conn_pool:conn_pool_base_test \
-    //test/common/http/http2:codec_impl_test \
-    //test/extensions/filters/http/header_mutation:header_mutation_test \
-    //test/extensions/filters/http/gcp_authn:gcp_authn_filter_test \
-    //test/extensions/filters/http/ext_proc:filter_test \
-    //test/extensions/filters/http/custom_response:config_test \
-    //test/extensions/filters/http/ext_proc:streaming_integration_test \
-    //test/extensions/filters/network/http_connection_manager:config_test )
 
-EXCLUDE_BATCH_TESTS=""
-for test in "${extra_tests[@]}"
-do
-  EXCLUDE_BATCH_TESTS+=" -${test}"
-done
-
-# Run tests without tests that timeout
 time bazel test \
   ${COMMON_FLAGS} \
   --build_tests_only \
+  --flaky_test_attempts=3 \
   -- \
   //test/... \
-  -//test/extensions/listener_managers/listener_manager:listener_manager_impl_quic_only_test \
-  $EXCLUDE_BATCH_TESTS
+  -//test/extensions/listener_managers/listener_manager:listener_manager_impl_quic_only_test
 
-# Run tests that where timing out in batch
-for test in "${extra_tests[@]}"
-do
-echo "Running Test " $test
-time bazel test \
-  ${COMMON_FLAGS} \
-  --build_tests_only \
-  -- \
-  $test 
-done
 


### PR DESCRIPTION
Use **bazel test flaky_test_attempt** option to try a failed test several times (three) as a workaround for TIMEOUT errors observed in ci.