### PR TITLE
[MAISTRA-2.4] CVEs-001-to-004

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -27,7 +27,10 @@ bug_fixes:
 - area: http
   change: |
     Fixed crash when HTTP request idle and per try timeouts occurs within backoff interval.
-
+- area: url matching
+  change: |
+    Fixed excessive CPU utilization when using regex URL template matcher.
+ 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -22,6 +22,10 @@ bug_fixes:
     Fixed a bug where TLVs with non utf8 characters were inserted as protobuf values into filter metadata circumventing
     ext_authz checks when ``failure_mode_allow`` is set to ``true``.
 
+- area: http
+  change: |
+    Fixed crash when HTTP request idle and per try timeouts occurs within backoff interval.
+
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -21,7 +21,9 @@ bug_fixes:
   change: |
     Fixed a bug where TLVs with non utf8 characters were inserted as protobuf values into filter metadata circumventing
     ext_authz checks when ``failure_mode_allow`` is set to ``true``.
-
+  change: |
+    Fix crash due to uncaught exception when the operating system does not support an address type (such as IPv6) that is
+    received in a proxy protocol header. Connections will instead be dropped/reset.
 - area: http
   change: |
     Fixed crash when HTTP request idle and per try timeouts occurs within backoff interval.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -19,6 +19,9 @@ bug_fixes:
 
 - area: proxy_protocol
   change: |
+    Fixed a crash when Envoy is configured for PROXY protocol on both a listener and cluster, and the listener receives
+    a PROXY protocol header with address type LOCAL (typically used for health checks).
+  change: |
     Fixed a bug where TLVs with non utf8 characters were inserted as protobuf values into filter metadata circumventing
     ext_authz checks when ``failure_mode_allow`` is set to ``true``.
   change: |
@@ -30,7 +33,7 @@ bug_fixes:
 - area: url matching
   change: |
     Fixed excessive CPU utilization when using regex URL template matcher.
- 
+     
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 

--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -37,4 +37,11 @@ time bazel test \
   --flaky_test_attempts=5 \
   -- \
   //test/... \
+  -//test/server:guarddog_impl_test \
   -//test/server:listener_manager_impl_quic_only_test
+
+time bazel test \
+  ${COMMON_FLAGS} \
+  --build_tests_only \
+  --flaky_test_attempts=5 \
+  //test/server:guarddog_impl_test

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
         ":socket_interface_lib",
         "//envoy/network:address_interface",
         "//source/common/common:assert_lib",
+        "//source/common/common:cleanup_lib",
         "//source/common/common:safe_memcpy_lib",
         "//source/common/common:statusor_lib",
         "//source/common/common:thread_lib",

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -211,9 +211,20 @@ std::string Ipv4Instance::sockaddrToString(const sockaddr_in& addr) {
   return std::string(start, str + BufferSize - start);
 }
 
+namespace {
+bool force_ipv4_unsupported_for_test = false;
+}
+
+Cleanup Ipv4Instance::forceProtocolUnsupportedForTest(bool new_val) {
+  bool old_val = force_ipv4_unsupported_for_test;
+  force_ipv4_unsupported_for_test = new_val;
+  return Cleanup([old_val]() { force_ipv4_unsupported_for_test = old_val; });
+}
+
+
 absl::Status Ipv4Instance::validateProtocolSupported() {
   static const bool supported = SocketInterfaceSingleton::get().ipFamilySupported(AF_INET);
-  if (supported) {
+  if (supported && !force_ipv4_unsupported_for_test) {
     return absl::OkStatus();
   }
   return absl::FailedPreconditionError("IPv4 addresses are not supported on this machine");
@@ -307,9 +318,20 @@ Ipv6Instance::Ipv6Instance(absl::Status& status, const sockaddr_in6& address, bo
   initHelper(address, v6only);
 }
 
+namespace {
+bool force_ipv6_unsupported_for_test = false;
+}
+
+Cleanup Ipv6Instance::forceProtocolUnsupportedForTest(bool new_val) {
+  bool old_val = force_ipv6_unsupported_for_test;
+  force_ipv6_unsupported_for_test = new_val;
+  return Cleanup([old_val]() { force_ipv6_unsupported_for_test = old_val; });
+}
+
+
 absl::Status Ipv6Instance::validateProtocolSupported() {
   static const bool supported = SocketInterfaceSingleton::get().ipFamilySupported(AF_INET6);
-  if (supported) {
+  if (supported && !force_ipv6_unsupported_for_test) {
     return absl::OkStatus();
   }
   return absl::FailedPreconditionError("IPv6 addresses are not supported on this machine");

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -11,6 +11,7 @@
 #include "envoy/network/socket.h"
 
 #include "source/common/common/assert.h"
+#include "source/common/common/cleanup.h"
 #include "source/common/common/statusor.h"
 
 namespace Envoy {
@@ -144,6 +145,13 @@ public:
   // given address if not.
   static absl::Status validateProtocolSupported();
 
+  /**
+   * For use in tests only.
+   * Force validateProtocolSupported() to return false for IPv4.
+   */
+  static Envoy::Cleanup forceProtocolUnsupportedForTest(bool new_val);
+
+
 private:
   /**
    * Construct from an existing unix IPv4 socket address (IP v4 address and port).
@@ -225,6 +233,13 @@ public:
 
   // Validate that IPv6 is supported on this platform
   static absl::Status validateProtocolSupported();
+
+  /**
+   * For use in tests only.
+   * Force validateProtocolSupported() to return false for IPv6.
+   */
+  static Envoy::Cleanup forceProtocolUnsupportedForTest(bool new_val);
+
 
 private:
   /**

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -995,6 +995,7 @@ void Filter::onResponseTimeout() {
 // Called when the per try timeout is hit but we didn't reset the request
 // (hedge_on_per_try_timeout enabled).
 void Filter::onSoftPerTryTimeout(UpstreamRequest& upstream_request) {
+  ASSERT(!upstream_request.retried());
   // Track this as a timeout for outlier detection purposes even though we didn't
   // cancel the request yet and might get a 2xx later.
   updateOutlierDetection(Upstream::Outlier::Result::LocalOriginTimeout, upstream_request,

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -511,11 +511,20 @@ void UpstreamRequest::setupPerTryTimeout() {
 
 void UpstreamRequest::onPerTryIdleTimeout() {
   ENVOY_STREAM_LOG(debug, "upstream per try idle timeout", *parent_.callbacks());
+  if (per_try_timeout_) {
+    // Disable the per try idle timer, so it does not trigger further retries
+    per_try_timeout_->disableTimer();
+  }
   stream_info_.setResponseFlag(StreamInfo::ResponseFlag::StreamIdleTimeout);
   parent_.onPerTryIdleTimeout(*this);
 }
 
 void UpstreamRequest::onPerTryTimeout() {
+  if (per_try_idle_timeout_) {
+    // Delete the per try idle timer, so it does not trigger further retries.
+    // The timer has to be deleted to prevent data flow from re-arming it.
+    per_try_idle_timeout_.reset();
+  }
   // If we've sent anything downstream, ignore the per try timeout and let the response continue
   // up to the global timeout
   if (!parent_.downstreamResponseStarted()) {

--- a/source/extensions/common/proxy_protocol/proxy_protocol_header.cc
+++ b/source/extensions/common/proxy_protocol/proxy_protocol_header.cc
@@ -44,6 +44,14 @@ void generateV1Header(const Network::Address::Ip& source_address,
 void generateV2Header(const std::string& src_addr, const std::string& dst_addr, uint32_t src_port,
                       uint32_t dst_port, Network::Address::IpVersion ip_version,
                       Buffer::Instance& out) {
+  if (src_addr.empty()) {
+    IS_ENVOY_BUG("Missing or incorrect source IP in src address");
+    return ;
+  }
+  if (dst_addr.empty()) {
+    IS_ENVOY_BUG("Missing or incorrect dest IP in dst address");
+    return ;
+  }                    
   out.add(PROXY_PROTO_V2_SIGNATURE, PROXY_PROTO_V2_SIGNATURE_LEN);
 
   const uint8_t version_and_command = PROXY_PROTO_V2_VERSION << 4 | PROXY_PROTO_V2_ONBEHALF_OF;

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -219,11 +219,19 @@ bool Filter::parseV2Header(const char* buf) {
         la4.sin_family = AF_INET;
         la4.sin_port = v4->dst_port;
         la4.sin_addr.s_addr = v4->dst_addr;
-        proxy_protocol_header_.emplace(
-            WireHeader{PROXY_PROTO_V2_HEADER_LEN, hdr_addr_len, PROXY_PROTO_V2_ADDR_LEN_INET,
-                       hdr_addr_len - PROXY_PROTO_V2_ADDR_LEN_INET, Network::Address::IpVersion::v4,
-                       std::make_shared<Network::Address::Ipv4Instance>(&ra4),
-                       std::make_shared<Network::Address::Ipv4Instance>(&la4)});
+        try {
+          // TODO(ggreenway): make this work without requiring operating system support for an
+          // address family.
+          proxy_protocol_header_.emplace(WireHeader{
+              PROXY_PROTO_V2_HEADER_LEN, hdr_addr_len, PROXY_PROTO_V2_ADDR_LEN_INET,
+              hdr_addr_len - PROXY_PROTO_V2_ADDR_LEN_INET, Network::Address::IpVersion::v4,
+              std::make_shared<Network::Address::Ipv4Instance>(&ra4),
+              std::make_shared<Network::Address::Ipv4Instance>(&la4)});
+        } catch (const EnvoyException& e) {
+          ENVOY_LOG(debug, "Proxy protocol failure: {}", e.what());
+          return false;
+        }
+
         return true;
       } else if (((proto_family & 0xf0) >> 4) == PROXY_PROTO_V2_AF_INET6) {
         PACKED_STRUCT(struct pp_ipv6_addr {
@@ -245,11 +253,18 @@ bool Filter::parseV2Header(const char* buf) {
         la6.sin6_port = v6->dst_port;
         safeMemcpy(&(la6.sin6_addr.s6_addr), &(v6->dst_addr));
 
-        proxy_protocol_header_.emplace(WireHeader{
-            PROXY_PROTO_V2_HEADER_LEN, hdr_addr_len, PROXY_PROTO_V2_ADDR_LEN_INET6,
-            hdr_addr_len - PROXY_PROTO_V2_ADDR_LEN_INET6, Network::Address::IpVersion::v6,
-            std::make_shared<Network::Address::Ipv6Instance>(ra6),
-            std::make_shared<Network::Address::Ipv6Instance>(la6)});
+        try {
+          proxy_protocol_header_.emplace(WireHeader{
+              PROXY_PROTO_V2_HEADER_LEN, hdr_addr_len, PROXY_PROTO_V2_ADDR_LEN_INET6,
+              hdr_addr_len - PROXY_PROTO_V2_ADDR_LEN_INET6, Network::Address::IpVersion::v6,
+              std::make_shared<Network::Address::Ipv6Instance>(ra6),
+              std::make_shared<Network::Address::Ipv6Instance>(la6)});
+        } catch (const EnvoyException& e) {
+          // TODO(ggreenway): make this work without requiring operating system support for an
+          // address family.
+          ENVOY_LOG(debug, "Proxy protocol failure: {}", e.what());
+          return false;
+        }
         return true;
       }
     }

--- a/source/extensions/path/match/uri_template/uri_template_match.cc
+++ b/source/extensions/path/match/uri_template/uri_template_match.cc
@@ -18,9 +18,8 @@ namespace UriTemplate {
 namespace Match {
 
 bool UriTemplateMatcher::match(absl::string_view path) const {
-  RE2 matching_pattern_regex = RE2(convertPathPatternSyntaxToRegex(path_template_).value());
   return RE2::FullMatch(Internal::toStringPiece(Http::PathUtil::removeQueryAndFragment(path)),
-                        matching_pattern_regex);
+                        matching_pattern_regex_);
 }
 
 absl::string_view UriTemplateMatcher::uriTemplate() const { return path_template_; }

--- a/source/extensions/path/match/uri_template/uri_template_match.h
+++ b/source/extensions/path/match/uri_template/uri_template_match.h
@@ -29,7 +29,8 @@ class UriTemplateMatcher : public Router::PathMatcher {
 public:
   explicit UriTemplateMatcher(
       const envoy::extensions::path::match::uri_template::v3::UriTemplateMatchConfig& config)
-      : path_template_(config.path_template()) {}
+      : path_template_(config.path_template()),
+        matching_pattern_regex_(convertPathPatternSyntaxToRegex(path_template_).value()) {}
 
   // Router::PathMatcher
   bool match(absl::string_view path) const override;
@@ -38,6 +39,7 @@ public:
 
 private:
   const std::string path_template_;
+  const RE2 matching_pattern_regex_;
 };
 
 } // namespace Match

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -9,6 +9,7 @@
 #include "source/common/api/os_sys_calls_impl.h"
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/event/dispatcher_impl.h"
+#include "source/common/network/address_impl.h"
 #include "source/common/network/connection_balancer_impl.h"
 #include "source/common/network/listen_socket_impl.h"
 #include "source/common/network/raw_buffer_socket.h"
@@ -230,6 +231,21 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ProxyProtocolTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
+TEST_P(ProxyProtocolTest, V1UnsupportedIPv4) {
+  connect(false);
+  Cleanup cleaner = Network::Address::Ipv4Instance::forceProtocolUnsupportedForTest(true);
+  write("PROXY TCP4 1.2.3.4 253.253.253.253 65535 1234\r\nmore data");
+  expectProxyProtoError();
+}
+
+TEST_P(ProxyProtocolTest, V1UnsupportedIPv6) {
+  connect(false);
+  Cleanup cleaner = Network::Address::Ipv6Instance::forceProtocolUnsupportedForTest(true);
+  write("PROXY TCP6 1:2:3::4 5:6::7:8 65535 1234\r\nmore data");
+  expectProxyProtoError();
+}
+
+
 TEST_P(ProxyProtocolTest, V1Basic) {
   connect();
   write("PROXY TCP4 1.2.3.4 253.253.253.253 65535 1234\r\nmore data");
@@ -382,6 +398,34 @@ TEST_P(ProxyProtocolTest, V2BasicV6) {
   EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
+}
+
+TEST_P(ProxyProtocolTest, V2UnsupportedIPv4) {
+  // A well-formed ipv4/tcp message, no extensions
+  constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49,
+                                0x54, 0x0a, 0x21, 0x11, 0x00, 0x0c, 0x01, 0x02, 0x03, 0x04,
+                                0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x00, 0x02, 'm',  'o',
+                                'r',  'e',  ' ',  'd',  'a',  't',  'a'};
+
+  connect(false);
+  Cleanup cleaner = Network::Address::Ipv4Instance::forceProtocolUnsupportedForTest(true);
+  write(buffer, sizeof(buffer));
+  expectProxyProtoError();
+}
+
+TEST_P(ProxyProtocolTest, V2UnsupportedIPv6) {
+  // A well-formed ipv6/tcp message, no extensions
+  constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49, 0x54,
+                                0x0a, 0x21, 0x22, 0x00, 0x24, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00,
+                                0x01, 0x01, 0x00, 0x02, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x02, 'm',  'o',  'r',
+                                'e',  ' ',  'd',  'a',  't',  'a'};
+
+  connect(false);
+  Cleanup cleaner = Network::Address::Ipv6Instance::forceProtocolUnsupportedForTest(true);
+  write(buffer, sizeof(buffer));
+  expectProxyProtoError();
 }
 
 TEST_P(ProxyProtocolTest, V2UnsupportedAF) {

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -546,4 +546,77 @@ TEST_P(HttpTimeoutIntegrationTest, RequestHeaderTimeout) {
   EXPECT_THAT(response, AllOf(HasSubstr("408"), HasSubstr("header")));
 }
 
+// Validate that Envoy correctly handles per try and per try IDLE timeouts
+// that are firing within the backoff interval.
+TEST_P(HttpTimeoutIntegrationTest, OriginalRequestCompletesBeforeBackoffTimer) {
+  auto host = config_helper_.createVirtualHost("example.com", "/test_retry");
+  config_helper_.addVirtualHost(host);
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        auto* route_config = hcm.mutable_route_config();
+        auto* virtual_host = route_config->mutable_virtual_hosts(1);
+        auto* route = virtual_host->mutable_routes(0)->mutable_route();
+        auto* retry_policy = route->mutable_retry_policy();
+        retry_policy->mutable_per_try_idle_timeout()->set_seconds(0);
+        // per try IDLE timeout is 400 ms
+        retry_policy->mutable_per_try_idle_timeout()->set_nanos(400 * 1000 * 1000);
+      });
+  initialize();
+
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  auto encoder_decoder = codec_client_->startRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "POST"},
+      {":path", "/test_retry"},
+      {":scheme", "http"},
+      {":authority", "example.com"},
+      {"x-forwarded-for", "10.0.0.1"},
+      {"x-envoy-retry-on", "5xx"},
+      // Enable hedge_on_per_try_timeout so that original request is not reset
+      {"x-envoy-hedge-on-per-try-timeout", "true"},
+      {"x-envoy-upstream-rq-timeout-ms", "500"},
+      // Make per try timeout the same as the per try idle timeout
+      // NOTE: it can be a bit longer, within the back off interval
+      {"x-envoy-upstream-rq-per-try-timeout-ms", "400"}});
+  auto response = std::move(encoder_decoder.second);
+  request_encoder_ = &encoder_decoder.first;
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+  codec_client_->sendData(*request_encoder_, 0, true);
+
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+
+  // Trigger per try timeout (but not global timeout). This will actually trigger
+  // both IDLE and request timeouts in the same I/O operation.
+  timeSystem().advanceTimeWait(std::chrono::milliseconds(400));
+
+  // Trigger retry (there's a 25ms backoff before it's issued).
+  timeSystem().advanceTimeWait(std::chrono::milliseconds(26));
+
+  // Wait for a second request to be sent upstream
+  FakeStreamPtr upstream_request2;
+
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request2));
+
+  ASSERT_TRUE(upstream_request2->waitForHeadersComplete());
+
+  ASSERT_TRUE(upstream_request2->waitForEndStream(*dispatcher_));
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+
+  // Respond to the second request (it does not matter which request gets response).
+  upstream_request2->encodeHeaders(response_headers, true);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  // The first request should be reset since we used the response from the second request.
+  ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
+
+  codec_client_->close();
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+
 } // namespace Envoy

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -36,6 +36,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/access_loggers/wasm:93.0"
 "source/extensions/clusters/common:68.2"
 "source/extensions/common:92.4"
+"source/extensions/common/proxy_protocol:93.8" # Adjusted for security patch
 "source/extensions/common/tap:92.4"
 "source/extensions/common/wasm:87.5" # flaky: be careful adjusting
 "source/extensions/common/wasm/ext:92.0"

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -930,6 +930,7 @@ negative
 netblock
 netblocks
 netfilter
+NLB
 nonblocking
 noncopyable
 nonresponsive


### PR DESCRIPTION
Fix the following CVEs:
[CVE-2024-23327]([GHSA-4h5x-x9vh-m29j](https://github.com/envoyproxy/envoy/security/advisories/GHSA-4h5x-x9vh-m29j)) 0001-Fix-crash-from-AWS-NLB-healthchecks-when-proxy-proto

[CVE-2024-23322]([GHSA-6p83-mfmh-qv38](https://github.com/envoyproxy/envoy/security/advisories/GHSA-6p83-mfmh-qv38))  0002-Fix-crash-when-idle-and-per-try-timeouts-occurs-with

[CVE-2024-23323]([GHSA-x278-4w4x-r7ch](https://github.com/envoyproxy/envoy/security/advisories/GHSA-x278-4w4x-r7ch))  0003-Cache-RE-object-in-uri-template-matcher

[CVE-2024-23325]([GHSA-5m7c-mrwr-pm26](https://github.com/envoyproxy/envoy/security/advisories/GHSA-5m7c-mrwr-pm26))  0004-Fix-crashes-when-proxyproto-receives-address-type-no

[CVE-2024-23324]([GHSA-gq3v-vvhj-96j6](https://github.com/envoyproxy/envoy/security/advisories/GHSA-gq3v-vvhj-96j6)) 0005-Proxy-protocol-sanitise-non-utf8-chars-in-TLVs 

https://issues.redhat.com/browse/OSSM-6046
