### PR TITLE
[MAISTRA 2.3] OSSM-6082 - Merge CVEs 001 to 005

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -1,11 +1,9 @@
 date: Pending
 
 behavior_changes:
-<<<<<<< HEAD
 - area: tls-inspector
   change: |
     the listener filter tls inspector's stats ``connection_closed`` and ``read_error`` are removed. The new stats are introduced for listener, ``downstream_peek_remote_close`` and ``read_error`` :ref:`listener stats <config_listener_stats>`.
-=======
 # *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
 - area: http
   change: |
@@ -16,9 +14,6 @@ behavior_changes:
     resets is applied. The connection is disconnected if more than 50% of resets are premature.
     Setting the runtime key ``envoy.restart_features.send_goaway_for_premature_rst_streams`` to ``false`` completely disables
     this check.
-<<<<<<< HEAD
->>>>>>> 01b62a78e9 (Close HTTP connections that prematurely reset streams)
-=======
 - area: http
   change: |
     Add runtime flag ``http.max_requests_per_io_cycle`` for setting the limit on the number of HTTP requests processed
@@ -26,7 +21,6 @@ behavior_changes:
     mitigates CPU starvation by connections that simultaneously send high number of requests by allowing requests from other
     connections to make progress. This runtime value can be set to 1 in the presence of abusive HTTP/2 or HTTP/3 connections.
     By default this limit is disabled.
->>>>>>> b8f05c054c (Limit on the number of HTTP requests processed from a connection in an I/O cycle)
 
 minor_behavior_changes:
 - area: thrift

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -211,7 +211,10 @@ new_features:
   change: |
     Fix crash due to uncaught exception when the operating system does not support an address type (such as IPv6) that is
     received in a proxy protocol header. Connections will instead be dropped/reset.
-    
+- area: http
+  change: |
+    Fixed crash when HTTP request idle and per try timeouts occurs within backoff interval.
+
 deprecated:
 - area: dubbo_proxy
   change: |

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -218,6 +218,10 @@ new_features:
   change: |
     fixed a crash when Envoy is configured for PROXY protocol on both a listener and cluster, and the listener receives
     a PROXY protocol header with address type LOCAL (typically used for health checks).
+- area: proxy_protocol
+  change: |
+    Fixed a bug where TLVs with non utf8 characters were inserted as protobuf values into filter metadata circumventing
+    ext_authz checks when ``failure_mode_allow`` is set to ``true``.
 deprecated:
 - area: dubbo_proxy
   change: |

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -207,7 +207,11 @@ new_features:
 - area: dubbo_proxy
   change: |
     added :ref:`metadata_match <envoy_v3_api_field_extensions.filters.network.dubbo_proxy.v3.RouteAction.metadata_match>` support to the dubbo proxy.
-
+- area: proxy_protocol
+  change: |
+    Fix crash due to uncaught exception when the operating system does not support an address type (such as IPv6) that is
+    received in a proxy protocol header. Connections will instead be dropped/reset.
+    
 deprecated:
 - area: dubbo_proxy
   change: |

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -214,7 +214,10 @@ new_features:
 - area: http
   change: |
     Fixed crash when HTTP request idle and per try timeouts occurs within backoff interval.
-
+- area: proxy protocol
+  change: |
+    fixed a crash when Envoy is configured for PROXY protocol on both a listener and cluster, and the listener receives
+    a PROXY protocol header with address type LOCAL (typically used for health checks).
 deprecated:
 - area: dubbo_proxy
   change: |

--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -32,5 +32,5 @@ time bazel build \
 time bazel test \
   ${COMMON_FLAGS} \
   --build_tests_only \
-  --flaky_test_attempts=3 \
+  --flaky_test_attempts=5 \
   //test/...

--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -33,4 +33,13 @@ time bazel test \
   ${COMMON_FLAGS} \
   --build_tests_only \
   --flaky_test_attempts=5 \
-  //test/...
+  -- \
+  //test/... \
+  -//test/server:guarddog_impl_test
+
+time bazel test \
+  ${COMMON_FLAGS} \
+  --build_tests_only \
+  --flaky_test_attempts=5 \
+  //test/server:guarddog_impl_test
+

--- a/maistra/run-ci.sh
+++ b/maistra/run-ci.sh
@@ -32,4 +32,5 @@ time bazel build \
 time bazel test \
   ${COMMON_FLAGS} \
   --build_tests_only \
+  --flaky_test_attempts=3 \
   //test/...

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
         ":socket_interface_lib",
         "//envoy/network:address_interface",
         "//source/common/common:assert_lib",
+        "//source/common/common:cleanup_lib",
         "//source/common/common:safe_memcpy_lib",
         "//source/common/common:statusor_lib",
         "//source/common/common:thread_lib",

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -199,9 +199,20 @@ std::string Ipv4Instance::sockaddrToString(const sockaddr_in& addr) {
   return std::string(start, str + BufferSize - start);
 }
 
+namespace {
+bool force_ipv4_unsupported_for_test = false;
+}
+
+Cleanup Ipv4Instance::forceProtocolUnsupportedForTest(bool new_val) {
+  bool old_val = force_ipv4_unsupported_for_test;
+  force_ipv4_unsupported_for_test = new_val;
+  return Cleanup([old_val]() { force_ipv4_unsupported_for_test = old_val; });
+}
+
+
 absl::Status Ipv4Instance::validateProtocolSupported() {
   static const bool supported = SocketInterfaceSingleton::get().ipFamilySupported(AF_INET);
-  if (supported) {
+  if (supported && !force_ipv4_unsupported_for_test) {
     return absl::OkStatus();
   }
   return absl::FailedPreconditionError("IPv4 addresses are not supported on this machine");
@@ -255,6 +266,17 @@ Ipv6Instance::Ipv6Instance(const sockaddr_in6& address, bool v6only,
   initHelper(address, v6only);
 }
 
+namespace {
+bool force_ipv6_unsupported_for_test = false;
+}
+
+Cleanup Ipv6Instance::forceProtocolUnsupportedForTest(bool new_val) {
+  bool old_val = force_ipv6_unsupported_for_test;
+  force_ipv6_unsupported_for_test = new_val;
+  return Cleanup([old_val]() { force_ipv6_unsupported_for_test = old_val; });
+}
+
+
 Ipv6Instance::Ipv6Instance(const std::string& address, const SocketInterface* sock_interface)
     : Ipv6Instance(address, 0, sockInterfaceOrDefault(sock_interface)) {}
 
@@ -297,7 +319,7 @@ Ipv6Instance::Ipv6Instance(absl::Status& status, const sockaddr_in6& address, bo
 
 absl::Status Ipv6Instance::validateProtocolSupported() {
   static const bool supported = SocketInterfaceSingleton::get().ipFamilySupported(AF_INET6);
-  if (supported) {
+  if (supported && !force_ipv6_unsupported_for_test) {
     return absl::OkStatus();
   }
   return absl::FailedPreconditionError("IPv6 addresses are not supported on this machine");

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -11,6 +11,7 @@
 #include "envoy/network/socket.h"
 
 #include "source/common/common/assert.h"
+#include "source/common/common/cleanup.h"
 #include "source/common/common/statusor.h"
 
 namespace Envoy {
@@ -137,6 +138,12 @@ public:
   // given address if not.
   static absl::Status validateProtocolSupported();
 
+  /**
+   * For use in tests only.
+   * Force validateProtocolSupported() to return false for IPv4.
+   */
+  static Envoy::Cleanup forceProtocolUnsupportedForTest(bool new_val);
+
 private:
   /**
    * Construct from an existing unix IPv4 socket address (IP v4 address and port).
@@ -218,6 +225,12 @@ public:
 
   // Validate that IPv6 is supported on this platform
   static absl::Status validateProtocolSupported();
+
+  /**
+   * For use in tests only.
+   * Force validateProtocolSupported() to return false for IPv6.
+   */
+  static Envoy::Cleanup forceProtocolUnsupportedForTest(bool new_val);
 
 private:
   /**

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -952,6 +952,7 @@ void Filter::onResponseTimeout() {
 // Called when the per try timeout is hit but we didn't reset the request
 // (hedge_on_per_try_timeout enabled).
 void Filter::onSoftPerTryTimeout(UpstreamRequest& upstream_request) {
+  ASSERT(!upstream_request.retried());
   // Track this as a timeout for outlier detection purposes even though we didn't
   // cancel the request yet and might get a 2xx later.
   updateOutlierDetection(Upstream::Outlier::Result::LocalOriginTimeout, upstream_request,

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -370,12 +370,21 @@ void UpstreamRequest::setupPerTryTimeout() {
 
 void UpstreamRequest::onPerTryIdleTimeout() {
   ENVOY_STREAM_LOG(debug, "upstream per try idle timeout", *parent_.callbacks());
+  if (per_try_timeout_) {
+    // Disable the per try idle timer, so it does not trigger further retries
+    per_try_timeout_->disableTimer();
+  }
   stream_info_.setResponseFlag(StreamInfo::ResponseFlag::StreamIdleTimeout);
   parent_.onPerTryIdleTimeout(*this);
 }
 
 void UpstreamRequest::onPerTryTimeout() {
-  // If we've sent anything downstream, ignore the per try timeout and let the response continue
+  if (per_try_idle_timeout_) {
+    // Delete the per try idle timer, so it does not trigger further retries.
+    // The timer has to be deleted to prevent data flow from re-arming it.
+    per_try_idle_timeout_.reset();
+  }
+ // If we've sent anything downstream, ignore the per try timeout and let the response continue
   // up to the global timeout
   if (!parent_.downstreamResponseStarted()) {
     ENVOY_STREAM_LOG(debug, "upstream per try timeout", *parent_.callbacks());

--- a/source/extensions/common/proxy_protocol/proxy_protocol_header.cc
+++ b/source/extensions/common/proxy_protocol/proxy_protocol_header.cc
@@ -44,6 +44,14 @@ void generateV1Header(const Network::Address::Ip& source_address,
 void generateV2Header(const std::string& src_addr, const std::string& dst_addr, uint32_t src_port,
                       uint32_t dst_port, Network::Address::IpVersion ip_version,
                       Buffer::Instance& out) {
+  if (src_addr.empty()) {
+    IS_ENVOY_BUG("Missing or incorrect source IP in src address");
+    return ;
+  }
+  if (dst_addr.empty()) {
+    IS_ENVOY_BUG("Missing or incorrect dest IP in dst address");
+    return ;
+  }
   out.add(PROXY_PROTO_V2_SIGNATURE, PROXY_PROTO_V2_SIGNATURE_LEN);
 
   const uint8_t version_and_command = PROXY_PROTO_V2_VERSION << 4 | PROXY_PROTO_V2_ONBEHALF_OF;

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -9,6 +9,7 @@
 #include "source/common/api/os_sys_calls_impl.h"
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/event/dispatcher_impl.h"
+#include "source/common/network/address_impl.h"
 #include "source/common/network/connection_balancer_impl.h"
 #include "source/common/network/listen_socket_impl.h"
 #include "source/common/network/raw_buffer_socket.h"
@@ -215,6 +216,20 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ProxyProtocolTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
+TEST_P(ProxyProtocolTest, V1UnsupportedIPv4) {
+  connect(false);
+  Cleanup cleaner = Network::Address::Ipv4Instance::forceProtocolUnsupportedForTest(true);
+  write("PROXY TCP4 1.2.3.4 253.253.253.253 65535 1234\r\nmore data");
+  expectProxyProtoError();
+}
+
+TEST_P(ProxyProtocolTest, V1UnsupportedIPv6) {
+  connect(false);
+  Cleanup cleaner = Network::Address::Ipv6Instance::forceProtocolUnsupportedForTest(true);
+  write("PROXY TCP6 1:2:3::4 5:6::7:8 65535 1234\r\nmore data");
+  expectProxyProtoError();
+}
+
 TEST_P(ProxyProtocolTest, V1Basic) {
   connect();
   write("PROXY TCP4 1.2.3.4 253.253.253.253 65535 1234\r\nmore data");
@@ -295,6 +310,34 @@ TEST_P(ProxyProtocolTest, V2BasicV6) {
   EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
+}
+
+TEST_P(ProxyProtocolTest, V2UnsupportedIPv4) {
+  // A well-formed ipv4/tcp message, no extensions
+  constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49,
+                                0x54, 0x0a, 0x21, 0x11, 0x00, 0x0c, 0x01, 0x02, 0x03, 0x04,
+                                0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x00, 0x02, 'm',  'o',
+                                'r',  'e',  ' ',  'd',  'a',  't',  'a'};
+
+  connect(false);
+  Cleanup cleaner = Network::Address::Ipv4Instance::forceProtocolUnsupportedForTest(true);
+  write(buffer, sizeof(buffer));
+  expectProxyProtoError();
+}
+
+TEST_P(ProxyProtocolTest, V2UnsupportedIPv6) {
+  // A well-formed ipv6/tcp message, no extensions
+  constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49, 0x54,
+                                0x0a, 0x21, 0x22, 0x00, 0x24, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00,
+                                0x01, 0x01, 0x00, 0x02, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x02, 'm',  'o',  'r',
+                                'e',  ' ',  'd',  'a',  't',  'a'};
+
+  connect(false);
+  Cleanup cleaner = Network::Address::Ipv6Instance::forceProtocolUnsupportedForTest(true);
+  write(buffer, sizeof(buffer));
+  expectProxyProtoError();
 }
 
 TEST_P(ProxyProtocolTest, V2UnsupportedAF) {

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -1182,6 +1182,70 @@ TEST_P(ProxyProtocolTest, V2ExtractMultipleTlvsOfInterest) {
   disconnect();
 }
 
+TEST_P(ProxyProtocolTest, V2ExtractMultipleTlvsOfInterestAndSanitiseNonUtf8) {
+  // A well-formed ipv4/tcp with a pair of TLV extensions is accepted.
+  constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49,
+                                0x54, 0x0a, 0x21, 0x11, 0x00, 0x39, 0x01, 0x02, 0x03, 0x04,
+                                0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x00, 0x02};
+  // A TLV of type 0x00 with size of 4 (1 byte is value).
+  constexpr uint8_t tlv1[] = {0x00, 0x00, 0x01, 0xff};
+  // A TLV of type 0x02 with size of 10 bytes (7 bytes are value). Second and last bytes in the
+  // value are non utf8 characters.
+  constexpr uint8_t tlv_type_authority[] = {0x02, 0x00, 0x07, 0x66, 0xfe,
+                                            0x6f, 0x2e, 0x63, 0x6f, 0xc1};
+  // A TLV of type 0x0f with size of 6 bytes (3 bytes are value).
+  constexpr uint8_t tlv3[] = {0x0f, 0x00, 0x03, 0xf0, 0x00, 0x0f};
+  // A TLV of type 0xea with size of 25 bytes (22 bytes are value). 7th and 21st bytes are non utf8
+  // characters.
+  constexpr uint8_t tlv_vpc_id[] = {0xea, 0x00, 0x16, 0x01, 0x76, 0x70, 0x63, 0x2d, 0x30,
+                                    0xc0, 0x35, 0x74, 0x65, 0x73, 0x74, 0x32, 0x66, 0x61,
+                                    0x36, 0x63, 0x36, 0x33, 0x68, 0xf9, 0x37};
+  constexpr uint8_t data[] = {'D', 'A', 'T', 'A'};
+
+  envoy::extensions::filters::listener::proxy_protocol::v3::ProxyProtocol proto_config;
+  auto rule_type_authority = proto_config.add_rules();
+  rule_type_authority->set_tlv_type(0x02);
+  rule_type_authority->mutable_on_tlv_present()->set_key("PP2 type authority");
+
+  auto rule_vpc_id = proto_config.add_rules();
+  rule_vpc_id->set_tlv_type(0xea);
+  rule_vpc_id->mutable_on_tlv_present()->set_key("PP2 vpc id");
+
+  connect(true, &proto_config);
+  write(buffer, sizeof(buffer));
+  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+
+  write(tlv1, sizeof(tlv1));
+  write(tlv_type_authority, sizeof(tlv_type_authority));
+  write(tlv3, sizeof(tlv3));
+  write(tlv_vpc_id, sizeof(tlv_vpc_id));
+  write(data, sizeof(data));
+  expectData("DATA");
+
+  EXPECT_EQ(1, server_connection_->streamInfo().dynamicMetadata().filter_metadata_size());
+
+  auto metadata = server_connection_->streamInfo().dynamicMetadata().filter_metadata();
+  EXPECT_EQ(1, metadata.size());
+  EXPECT_EQ(1, metadata.count(ProxyProtocol));
+
+  auto fields = metadata.at(ProxyProtocol).fields();
+  EXPECT_EQ(2, fields.size());
+  EXPECT_EQ(1, fields.count("PP2 type authority"));
+  EXPECT_EQ(1, fields.count("PP2 vpc id"));
+
+  const char replacement = 0x21;
+  auto value_type_authority = fields.at("PP2 type authority").string_value();
+  // Non utf8 characters have been replaced with `0x21` (`!` character).
+  ASSERT_THAT(value_type_authority,
+              ElementsAre(0x66, replacement, 0x6f, 0x2e, 0x63, 0x6f, replacement));
+
+  auto value_vpc_id = fields.at("PP2 vpc id").string_value();
+  ASSERT_THAT(value_vpc_id,
+              ElementsAre(0x01, 0x76, 0x70, 0x63, 0x2d, 0x30, replacement, 0x35, 0x74, 0x65, 0x73,
+                          0x74, 0x32, 0x66, 0x61, 0x36, 0x63, 0x36, 0x33, 0x68, replacement, 0x37));
+  disconnect();
+}
+
 TEST_P(ProxyProtocolTest, V2WillNotOverwriteTLV) {
   // A well-formed ipv4/tcp with a pair of TLV extensions is accepted
   constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49,

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -546,4 +546,76 @@ TEST_P(HttpTimeoutIntegrationTest, RequestHeaderTimeout) {
   EXPECT_THAT(response, AllOf(HasSubstr("408"), HasSubstr("header")));
 }
 
+// Validate that Envoy correctly handles per try and per try IDLE timeouts
+// that are firing within the backoff interval.
+TEST_P(HttpTimeoutIntegrationTest, OriginalRequestCompletesBeforeBackoffTimer) {
+  auto host = config_helper_.createVirtualHost("example.com", "/test_retry");
+  config_helper_.addVirtualHost(host);
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        auto* route_config = hcm.mutable_route_config();
+        auto* virtual_host = route_config->mutable_virtual_hosts(1);
+        auto* route = virtual_host->mutable_routes(0)->mutable_route();
+        auto* retry_policy = route->mutable_retry_policy();
+        retry_policy->mutable_per_try_idle_timeout()->set_seconds(0);
+        // per try IDLE timeout is 400 ms
+        retry_policy->mutable_per_try_idle_timeout()->set_nanos(400 * 1000 * 1000);
+      });
+  initialize();
+
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  auto encoder_decoder = codec_client_->startRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "POST"},
+      {":path", "/test_retry"},
+      {":scheme", "http"},
+      {":authority", "example.com"},
+      {"x-forwarded-for", "10.0.0.1"},
+      {"x-envoy-retry-on", "5xx"},
+      // Enable hedge_on_per_try_timeout so that original request is not reset
+      {"x-envoy-hedge-on-per-try-timeout", "true"},
+      {"x-envoy-upstream-rq-timeout-ms", "500"},
+      // Make per try timeout the same as the per try idle timeout
+      // NOTE: it can be a bit longer, within the back off interval
+      {"x-envoy-upstream-rq-per-try-timeout-ms", "400"}});
+  auto response = std::move(encoder_decoder.second);
+  request_encoder_ = &encoder_decoder.first;
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+  codec_client_->sendData(*request_encoder_, 0, true);
+
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+
+  // Trigger per try timeout (but not global timeout). This will actually trigger
+  // both IDLE and request timeouts in the same I/O operation.
+  timeSystem().advanceTimeWait(std::chrono::milliseconds(400));
+
+  // Trigger retry (there's a 25ms backoff before it's issued).
+  timeSystem().advanceTimeWait(std::chrono::milliseconds(26));
+
+  // Wait for a second request to be sent upstream
+  FakeStreamPtr upstream_request2;
+
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request2));
+
+  ASSERT_TRUE(upstream_request2->waitForHeadersComplete());
+
+  ASSERT_TRUE(upstream_request2->waitForEndStream(*dispatcher_));
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+
+  // Respond to the second request (it does not matter which request gets response).
+  upstream_request2->encodeHeaders(response_headers, true);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  // The first request should be reset since we used the response from the second request.
+  ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
+
+  codec_client_->close();
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
 } // namespace Envoy

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -34,6 +34,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/access_loggers/wasm:93.0"
 "source/extensions/clusters/common:68.2"
 "source/extensions/common:91.9"
+"source/extensions/common/proxy_protocol:93.8" # Adjusted for security patch
 "source/extensions/common/tap:92.9"
 "source/extensions/common/wasm:87.5" # flaky: be careful adjusting
 "source/extensions/common/wasm/ext:92.0"

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -892,6 +892,7 @@ negative
 netblock
 netblocks
 netfilter
+NLB
 nonblocking
 noncopyable
 nonresponsive


### PR DESCRIPTION
Merged applicable CVEs from the upstream (see https://issues.redhat.com/browse/OSSM-6082):

[CVE-2024-23327]([GHSA-4h5x-x9vh-m29j](https://github.com/envoyproxy/envoy/security/advisories/GHSA-4h5x-x9vh-m29j)) 0001-Fix-crash-from-AWS-NLB-healthchecks-when-proxy-proto

[CVE-2024-23322]([GHSA-6p83-mfmh-qv38](https://github.com/envoyproxy/envoy/security/advisories/GHSA-6p83-mfmh-qv38))  0002-Fix-crash-when-idle-and-per-try-timeouts-occurs-with

[CVE-2024-23325]([GHSA-5m7c-mrwr-pm26](https://github.com/envoyproxy/envoy/security/advisories/GHSA-5m7c-mrwr-pm26))  0004-Fix-crashes-when-proxyproto-receives-address-type-no

[CVE-2024-23324] [GHSA-gq3v-vvhj-96j6 ](https://github.com/envoyproxy/envoy/security/advisories/GHSA-gq3v-vvhj-96j6) 0005-Proxy-protocol-sanitise-non-utf8-chars-in-TLVs

Moreover, workarounds for TIMEOUT in ci:
CI TIMEOUT workaround: use bazel "flaky_test_attempt" option
Increase to 5 the value for --flaky_test_attempts
Test TIMEOUT: run guarddog_impl_test as a single test