### PR TITLE
OSSM-6578 backports: backporting PR#32093 cookie session: support 0 ttl

### DIFF
--- a/api/envoy/type/http/v3/cookie.proto
+++ b/api/envoy/type/http/v3/cookie.proto
@@ -22,7 +22,7 @@ message Cookie {
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   // Duration of cookie. This will be used to set the expiry time of a new cookie when it is
-  // generated. Set this to 0 to use a session cookie.
+  // generated. Set this to 0s to use a session cookie and disable cookie expiration.
   google.protobuf.Duration ttl = 2 [(validate.rules).duration = {gte {}}];
 
   // Path of cookie. This will be used to set the path of a new cookie when it is generated.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -17,6 +17,9 @@ new_features:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: stateful_session
+  change: |
+    Support 0 TTL for proto-encoded cookies, which disables cookie expiration by Envoy.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/http/stateful_session/cookie/cookie.cc
+++ b/source/extensions/http/stateful_session/cookie/cookie.cc
@@ -11,9 +11,26 @@ namespace Cookie {
 void CookieBasedSessionStateFactory::SessionStateImpl::onUpdate(
     const Upstream::HostDescription& host, Envoy::Http::ResponseHeaderMap& headers) {
   absl::string_view host_address = host.address()->asStringView();
+  std::string encoded_address;
   if (!upstream_address_.has_value() || host_address != upstream_address_.value()) {
-    const std::string encoded_address =
-        Envoy::Base64::encode(host_address.data(), host_address.length());
+    if (Runtime::runtimeFeatureEnabled(
+            "envoy.reloadable_features.stateful_session_encode_ttl_in_cookie")) {
+      // Build proto message
+      envoy::Cookie cookie;
+      cookie.set_address(std::string(host_address));
+      if (factory_.ttl_ != std::chrono::seconds::zero()) {
+        const auto expiry_time = std::chrono::duration_cast<std::chrono::seconds>(
+            (time_source_.monotonicTime() + std::chrono::seconds(factory_.ttl_))
+                .time_since_epoch());
+        cookie.set_expires(expiry_time.count());
+      }
+      std::string proto_string;
+      cookie.SerializeToString(&proto_string);
+
+      encoded_address = Envoy::Base64::encode(proto_string.data(), proto_string.length());
+    } else {
+      encoded_address = Envoy::Base64::encode(host_address.data(), host_address.length());
+    }
     headers.addReferenceKey(Envoy::Http::Headers::get().SetCookie,
                             factory_.makeSetCookie(encoded_address));
   }

--- a/source/extensions/http/stateful_session/cookie/cookie.h
+++ b/source/extensions/http/stateful_session/cookie/cookie.h
@@ -54,9 +54,38 @@ public:
 private:
   absl::optional<std::string> parseAddress(const Envoy::Http::RequestHeaderMap& headers) const {
     const std::string cookie_value = Envoy::Http::Utility::parseCookieValue(headers, name_);
-    std::string address = Envoy::Base64::decode(cookie_value);
+    if (cookie_value.empty()) {
+      return absl::nullopt;
+    }
+    const std::string decoded_value = Envoy::Base64::decode(cookie_value);
+    std::string address;
 
-    return !address.empty() ? absl::make_optional(std::move(address)) : absl::nullopt;
+    // Try to interpret the cookie as proto payload.
+    // Otherwise treat it as "old" style format, which is ip-address:port.
+    envoy::Cookie cookie;
+    if (cookie.ParseFromString(decoded_value)) {
+      address = cookie.address();
+      if (address.empty()) {
+        return absl::nullopt;
+      }
+
+      if (cookie.expires() != 0) {
+        const std::chrono::seconds expiry_time(cookie.expires());
+        const auto now = std::chrono::duration_cast<std::chrono::seconds>(
+            (time_source_.monotonicTime()).time_since_epoch());
+        if (now > expiry_time) {
+          // Ignore the address extracted from the cookie. This will cause
+          // upstream cluster to select a new host and new cookie will be generated.
+          return absl::nullopt;
+        }
+      }
+    } else {
+      ENVOY_LOG_ONCE_MISC(
+          warn, "Non-proto cookie format detected. This format will be rejected in the future.");
+      address = decoded_value;
+    }
+
+    return address.empty() ? absl::nullopt : absl::make_optional(std::move(address));
   }
 
   std::string makeSetCookie(const std::string& address) const {

--- a/test/extensions/http/stateful_session/cookie/cookie_test.cc
+++ b/test/extensions/http/stateful_session/cookie/cookie_test.cc
@@ -41,13 +41,38 @@ TEST(CookieBasedSessionStateFactoryTest, SessionStateTest) {
     EXPECT_CALL(mock_host, address()).WillOnce(testing::Return(upstream_host));
 
     Envoy::Http::TestResponseHeaderMapImpl response_headers;
-    session_state->onUpdate(mock_host, response_headers);
+    auto session_state = factory.create(request_headers);
+    EXPECT_EQ(absl::nullopt, session_state->upstreamAddress());
+
+    auto upstream_host = std::make_shared<Envoy::Network::Address::Ipv4Instance>("1.2.3.4", 80);
+    EXPECT_CALL(mock_host, address()).Times(2).WillRepeatedly(testing::Return(upstream_host));
 
     // No valid address then update it by set-cookie.
-    EXPECT_EQ(response_headers.get_("set-cookie"),
-              Envoy::Http::Utility::makeSetCookieValue("override_host",
-                                                       Envoy::Base64::encode("1.2.3.4:80", 10), "",
-                                                       std::chrono::seconds(0), true));
+    // Run the test twice: once with proto cookie format and once
+    // with "old" style plain address.
+    for (bool use_proto : std::vector<bool>({true, false})) {
+      std::string cookie_content;
+      if (use_proto) {
+        envoy::Cookie cookie;
+        cookie.set_address("1.2.3.4:80");
+        // The expiration field is not set in the cookie because TTL is 0 in the config.
+        cookie.SerializeToString(&cookie_content);
+      } else {
+        cookie_content = "1.2.3.4:80";
+      }
+      Runtime::maybeSetRuntimeGuard(
+          "envoy.reloadable_features.stateful_session_encode_ttl_in_cookie", use_proto);
+
+      Envoy::Http::TestResponseHeaderMapImpl response_headers;
+      // Check the format of the cookie sent back to client.
+      session_state->onUpdate(mock_host, response_headers);
+      Envoy::Http::CookieAttributeRefVector cookie_attributes;
+      EXPECT_EQ(response_headers.get_("set-cookie"),
+                Envoy::Http::Utility::makeSetCookieValue(
+                    "override_host",
+                    Envoy::Base64::encode(cookie_content.c_str(), cookie_content.length()), "",
+                    std::chrono::seconds(0), true, cookie_attributes));
+    }
   }
 
   {
@@ -100,6 +125,51 @@ TEST(CookieBasedSessionStateFactoryTest, SessionStateTest) {
   }
 }
 
+<<<<<<< HEAD
+=======
+TEST(CookieBasedSessionStateFactoryTest, SessionStateProtoCookie) {
+  CookieBasedSessionStateProto config;
+  config.mutable_cookie()->set_name("override_host");
+  config.mutable_cookie()->set_path("/path");
+  config.mutable_cookie()->mutable_ttl()->set_seconds(5);
+  Event::SimulatedTimeSystem time_simulator;
+  time_simulator.setMonotonicTime(std::chrono::seconds(1000));
+  CookieBasedSessionStateFactory factory(config, time_simulator);
+
+  std::string cookie_content;
+  envoy::Cookie cookie;
+  cookie.set_address("2.3.4.5:80");
+  cookie.set_expires(1005);
+  cookie.SerializeToString(&cookie_content);
+  // PROTO format - expired cookie
+  time_simulator.setMonotonicTime(std::chrono::seconds(1006));
+  Envoy::Http::TestRequestHeaderMapImpl request_headers = {
+      {":path", "/path"},
+      {"cookie",
+       "override_host=" + Envoy::Base64::encode(cookie_content.c_str(), cookie_content.length())}};
+  auto session_state = factory.create(request_headers);
+  EXPECT_EQ(absl::nullopt, session_state->upstreamAddress());
+
+  // PROTO format - no "expired field"
+  cookie.clear_expires();
+  cookie.SerializeToString(&cookie_content);
+  request_headers = {{":path", "/path"},
+                     {"cookie", "override_host=" + Envoy::Base64::encode(cookie_content.c_str(),
+                                                                         cookie_content.length())}};
+  session_state = factory.create(request_headers);
+  EXPECT_EQ("2.3.4.5:80", session_state->upstreamAddress().value());
+
+  // PROTO format - pass incorrect format.
+  // The content should be treated as "old" style encoding.
+  cookie_content = "blahblah";
+  request_headers = {{":path", "/path"},
+                     {"cookie", "override_host=" + Envoy::Base64::encode(cookie_content.c_str(),
+                                                                         cookie_content.length())}};
+  session_state = factory.create(request_headers);
+  EXPECT_EQ("blahblah", session_state->upstreamAddress());
+}
+
+>>>>>>> 9ae0a01a78 (cookie session: support 0 ttl (#32093))
 TEST(CookieBasedSessionStateFactoryTest, SessionStatePathMatchTest) {
   {
     // Any request path will be accepted for empty cookie path.


### PR DESCRIPTION

Related PR: https://github.com/envoyproxy/envoy/pull/32093
and
https://github.com/envoyproxy/envoy/pull/35480

backporting this into maistra-2.5 envoy
