### PR TITLE
fix: preserve the original cert validation if extra checks is skipped

### DIFF
--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
@@ -248,7 +248,7 @@ int DefaultCertValidator::doSynchronousVerifyCertChain(
       Envoy::Ssl::ClientValidationStatus::NotValidated;
   bool success = verifyCertAndUpdateStatus(&leaf_cert, transport_socket_options, detailed_status,
                                            nullptr, nullptr);
-  if (ssl_extended_info) {
+  if (ssl_extended_info && detailed_status != Envoy::Ssl::ClientValidationStatus::NotValidated) {
     ssl_extended_info->setCertificateValidationStatus(detailed_status);
   }
   if (!success) {


### PR DESCRIPTION
There are 2 sets of certificate validation that happens, the first [one](https://github.com/maistra/envoy/blob/b65364810e2963ebb175ca62943d3db7150f35b8/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc#L236) is successful but then the additional [validation](https://github.com/maistra/envoy/blob/b65364810e2963ebb175ca62943d3db7150f35b8/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc#L292) is skipped but we overwrite the status of the first validation marking it as NotValidated.
This leads to false [results](https://github.com/maistra/envoy/blob/b65364810e2963ebb175ca62943d3db7150f35b8/source/extensions/transport_sockets/tls/ssl_handshaker.cc#L34) when validating the peer Certificate. A certificate that was successfully validated fails validation because of this bug. Envoy uses the [validated](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html#config-route-v3-routematch-tlscontextmatchoptions) and presented predicates and if the validated has incorrect results the TLS connection is aborted.
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
